### PR TITLE
Remove Github from list of social handles

### DIFF
--- a/join.md
+++ b/join.md
@@ -22,7 +22,7 @@ Our Slack is governed by the principles and rules in our [Community Guide](/comm
     <input id="name" type="text" required name="name">
   </div>
   <div>
-    <label for="social">Please provide two links to social handles (personal website, Twitter, Github, Medium, etc.):</label>
+    <label for="social">Please provide two links to social handles (Twitter, Medium, personal blog, etc.):</label>
     <input id="social" required type="url" name="social_media_1">
     <input type="url" required name="social_media_2">
   </div>


### PR DESCRIPTION
When people want to join our Slack or TWC mailing list, we ask them to provide a few social handles as part of a lightweight vetting process. There have been criticism that having `Github` in the list has unintentionally alienated non-technical folks, making them think that we are trying to prevent them from joining. This PR removes `Github` and changes the phrase `personal website` to `personal blog`   — as it is probably unusual for non-technical people to have a personal website as well.

:v: