### PR TITLE
Remove events calendar link from homepage

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -58,7 +58,6 @@ layout: default
     <ul>
       <li><a href="/subscribe">Slack</a></li>
       <li><a href="/subscribe">Newsletter</a></li>
-      <li><a href="/events">Events Calendar</a></li>
       <li><a target="_blank" href="https://sites.google.com/view/tech-workers-coalition/learning-club">Learning Club</a></li>
     </ul>
     <h3>TWC on social media</h3>


### PR DESCRIPTION
Now that there are numerous locals and they are linked to above, it doesn't really make sense to have a main events link here. This page is still used for the Seattle link, and they are the primary users of that page.