### PR TITLE
Add Seattle local page

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -51,7 +51,7 @@ layout: default
       <a href="/dc">DC</a>,
       <a href="/nyc">NYC</a>,
       <a href="/pdx">PDX</a>,
-      <a href="/events">Seattle</a>,
+      <a href="/seattle">Seattle</a>,
        and <a href="/sf-bay-area">SF Bay Area</a>.
     </p>
     <h3>Join the discussion & know the latest</h3>

--- a/calendar.md
+++ b/calendar.md
@@ -1,8 +1,0 @@
----
-layout: page
-title: Events
-permalink: /events/
-show_in_footer: true
----
-
-<iframe src="https://calendar.google.com/calendar/embed?showTabs=0&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=jo99u8cu70q0b1in00kpf6ssns%40group.calendar.google.com&amp;color=%23B1365F&amp;src=40c5rl0s6h91n1k9ddssb4n1e0%40group.calendar.google.com&amp;color=%235F6B02&amp;ctz=America%2FLos_Angeles" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>

--- a/city_local/seattle.md
+++ b/city_local/seattle.md
@@ -1,0 +1,9 @@
+---
+layout: page
+title: TWC Seattle
+permalink: /seattle/
+---
+<style>h1, .main-wrapper h2, h3 {text-align: left; font-weight: bold;}</style>
+# Seattle Tech Workers Coalition
+
+<iframe src="https://calendar.google.com/calendar/embed?showTabs=0&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=40c5rl0s6h91n1k9ddssb4n1e0%40group.calendar.google.com&amp;color=%235F6B02&amp;ctz=America%2FLos_Angeles" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>


### PR DESCRIPTION
Move Seattle from using general events page to having its own page. Remove general events page since this is no longer relevant and is not used elsewhere.