### PR TITLE
Small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TWC Site
 
-This repository is responsible for most content visible on the website [TechWorkersCoalition.co](https://TechWorkersCoalition.co). The site is made with a static site generator called [Jekyll](https://jekyllrb.com/) in a language called ruby.
+This repository is responsible for most content visible on the website [techworkerscoalition.org](https://techworkerscoalition.org). The site is made with a static site generator called [Jekyll](https://jekyllrb.com/) in a language called Ruby.
 
 ## Getting Started
 

--- a/city_local/berlin.md
+++ b/city_local/berlin.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Berlin Local
+title: TWC Berlin
 permalink: /berlin/
 ---
 <style>h1, .main-wrapper h2, h3 {text-align: left; font-weight: bold;}</style>

--- a/city_local/dc.md
+++ b/city_local/dc.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: DC Local 
+title: TWC DC
 permalink: /dc/
 ---
 

--- a/city_local/nyc.md
+++ b/city_local/nyc.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: NYC Local
+title: TWC NYC
 permalink: /nyc/
 ---
 <style>.event{padding:24px}.event:nth-child(odd){background:#f8f8f8}.event div,.event h3{margin:0 0 5px}.flex{align-items:center;display:flex}.jBetween{justify-content:space-between}.eventMeta b{font-size:16px}.event a{line-height:1}.event p{color:#444;font-size:18px;line-height:24px;margin:0;max-width:960px}#calendarContainer{padding:0 0 20px}.social{list-style:none;margin:0;padding:0}.bottomLinks a{display:block;font-size:18px;line-height:1;padding:12px}.calendarLink{display:block;font-size:18px;line-height:1}.marg{margin:0 5px}.pad{padding:12px 0 24px}.main-wrapper main{max-width:1024px;padding-left:1.5em;padding-right:1.5em}#new-york-city-tech-workers-coalition{font-size:48px;line-height:56px;margin:0}.blurb{color:#444;font-size:21px;line-height:32px}@media screen and (max-width:920px){.header .supporting-links li:nth-child(1),.header .supporting-links li:nth-child(2){display:none}}@media screen and (max-width:640px){.header .supporting-links li:nth-child(1),.header .supporting-links li:nth-child(2),.header .work{display:none}#new-york-city-tech-workers-coalition{font-size:32px;line-height:36px}.clamp{-webkit-box-orient:vertical;-webkit-line-clamp:3;display:-webkit-box;overflow:hidden}.calendarLink{margin:12px 0 0}.hideMobile{display:none}.flex{align-items:initial;flex-direction:column}.event{padding:12px}.bottomLinks a{padding:6px 0}}</style>

--- a/city_local/pdx.md
+++ b/city_local/pdx.md
@@ -8,7 +8,7 @@ permalink: /pdx/
 This is the Portland, OR chapter of the TWC.
 
 ## About
-- We are a coalition of workers in and around the tech industry, labour organisers, community organizers, and friends.
+- We are a coalition of workers in and around the tech industry, labor organizers, community organizers, and friends.
 
 ## Connect With Us
 - Visit our [Google Calendar](https://calendar.google.com/calendar/b/1?cid=dHdjcGR4QGdtYWlsLmNvbQ) to find the latest events.

--- a/city_local/pdx.md
+++ b/city_local/pdx.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: PDX Local
+title: TWC PDX
 permalink: /pdx/
 ---
 <style>h1, .main-wrapper h2, h3 {text-align: left; font-weight: bold;}</style>

--- a/city_local/sf-bay-area.md
+++ b/city_local/sf-bay-area.md
@@ -8,7 +8,7 @@ permalink: /sf-bay-area/
 This is the SF Bay Area (San Francisco, Oakland, and Berkeley) chapter of the TWC.
 
 ## About
-- We are a coalition of workers in and around the tech industry, labour organisers, community organizers, and friends.
+- We are a coalition of workers in and around the tech industry, labor organizers, community organizers, and friends.
 
 ## Connect With Us
 - Visit our [Meetup](https://www.meetup.com/Tech-Workers-Coalition/) to find the latest events.

--- a/city_local/sf-bay-area.md
+++ b/city_local/sf-bay-area.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: SF Bay Area Local
+title: TWC SF Bay Area
 permalink: /sf-bay-area/
 ---
 <style>h1, .main-wrapper h2, h3 {text-align: left; font-weight: bold;}</style>


### PR DESCRIPTION
* Fix broken link in README to refer to techworkerscoalition.org
* Rename titles for all locals because "Seattle Local" alone in a tab bar is confusing; "TWC Seattle" is much more clear and is the phrasing most commonly used when speaking about locals
* Fix errant European spelling that got mixed up in American local pages