### PR TITLE
fix header break on intermediate viewport

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,6 +1,8 @@
 <header class="header" role="banner">
-  <h1 class="logo"><a href="/">{{ site.title }}</h1>
-  <p class="work">Tech <span class="link">Workers</span> Coalition</p></a>
+  <div>
+    <h1 class="logo"><a href="/">{{ site.title }}</h1>
+    <p class="work">Tech <span class="link">Workers</span> Coalition</p></a>
+  </div>
   <ul class="supporting-links">
     {% for link in site.header_links %}
       <li><a href="{{ link.url }}">{{ link.text }}</a></li>

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@import "variables";
 
 header {
   padding-top: 0.25em;
@@ -8,15 +8,15 @@ header {
   }
 }
 
-
 .header {
-
-  // overflow: auto;
   position: fixed;
-  box-shadow: 2px 0 10px rgba(0,0,0,.2);
+  box-shadow: 2px 0 10px rgba(0, 0, 0, 0.2);
   width: 100%;
   background-color: white;
   z-index: 9;
+
+  display: flex;
+  justify-content: space-between;
 
   .logo {
     background-color: none;
@@ -54,12 +54,9 @@ header {
     font-size: 1.125em;
     float: right;
     list-style-type: none;
-    // margin: 0;
     padding: 0;
-    // width: 40%;
     display: inline-flex;
     margin-right: 1em;
-
 
     @include mobile {
       font-size: 1em;
@@ -85,16 +82,15 @@ header {
         color: #212121;
       }
       &:hover {
-        color: #E6141B;
+        color: #e6141b;
       }
       &:focus {
-        color: #E6141B;
+        color: #e6141b;
       }
       &:active {
         color: #212121;
       }
     }
-
 
     li {
       text-transform: uppercase;
@@ -103,14 +99,13 @@ header {
       padding-left: 1em;
       padding-right: 1em;
 
-
       &:nth-child(3) a {
         background-color: #212121;
         color: white;
         padding: 8px 25px;
         border-radius: 100px;
         &:hover {
-          background-color: #E6141B;
+          background-color: #e6141b;
         }
       }
     }
@@ -118,16 +113,14 @@ header {
 
   .work {
     font-weight: 100;
-    margin: 1em;
+    margin-left: 1em;
     display: -webkit-inline-box;
     text-transform: uppercase;
     text-decoration: none;
     font-size: 24px;
-    color: #E6141B;
-    // padding-top: 24px;
-    // padding-bottom: 24px;
+    color: #e6141b;
 
-    @include mobile {
+    @media screen and (max-width: 915px) {
       display: none;
     }
 
@@ -136,6 +129,4 @@ header {
       color: #212121;
     }
   }
-
-
 }

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -3,7 +3,7 @@ $black: rgb(33, 33, 33);
 $white: rgb(255, 255, 255);
 $grey: rgb(234, 234, 234);
 $black: rgb(2, 14, 15);
-$tablet-width: 620px;
+$tablet-width: 760px;
 $mobile-width: 420px;
 
 @mixin tablet {


### PR DESCRIPTION
## Summary

In order to visualize the translations navigation we need to make sure the header isn't breaking on certain viewports.

Before | After
------------ | -------------
![Screen Shot 2019-08-17 at 11 49 58](https://user-images.githubusercontent.com/8156337/63209767-b9471d00-c0e5-11e9-9975-54066ea23676.png) | ![Screen Shot 2019-08-17 at 11 50 15](https://user-images.githubusercontent.com/8156337/63209773-c8c66600-c0e5-11e9-95af-ca53f2f4e105.png)