### PR TITLE
adds twc atx twitter to city local page

### DIFF
--- a/city_local/austin.md
+++ b/city_local/austin.md
@@ -12,6 +12,7 @@ This is the Austin, TX chapter of the TWC.
 
 ## Connect With Us
 - Visit our [Meetup](https://www.meetup.com/Tech-Workers-Coalition-ATX/) to find the latest events.
+- Follow us on Twitter at [@twcatx](https://twitter.com/twcatx).
 
 ## Code of Conduct
 All meetings and communications are covered under the [TWC Code of Conduct](https://techworkerscoalition.org/community-guide/). The privacy and safety of our members is important to us. Sharing the identity of members and or taking/sharing photos are strictly forbidden unless express consent is given.


### PR DESCRIPTION
Twitter handle wasn't registered before last PR, but now it is, so this PR adds that to our city_local page.