### PR TITLE
Add link to next meeting on TWC London page

### DIFF
--- a/city_local/london.md
+++ b/city_local/london.md
@@ -22,9 +22,10 @@ in September 2019.
 
 ## Connect With Us
 
-- Currently the best way to see what we're up to and find out about our next
-  meeting is to follow us on Twitter, at
+- Currently the best way to see what we're up to is to follow us on Twitter, at
   [@TechWorkersLDN](https://twitter.com/TechWorkersLDN).
+- You can find out about and [sign up to attend our next meeting
+  here](https://bobwhitelock.co.uk/next-twc-london-meeting).
 - We can be securely contacted via email, at
 [techworkersldn@protonmail.com](mailto:techworkersldn@protonmail.com).
 - We are also on [the TWC Slack](/subscribe), in the `#local-uk-london` channel.


### PR DESCRIPTION
We wanted to have a link to the next TWC London meeting on this page, but don't want this to keep getting out of date or have to keep bothering you with new PRs just to update this link. This has been done using a URL which will redirect on a domain I control, so I can just keep updating this to point to the latest meeting monthly/weekly as needed, without needing to keep making new PRs. Hopefully this is acceptable. Thanks! :slightly_smiling_face: