### PR TITLE
Add a link to London's zine

### DIFF
--- a/city_local/london.md
+++ b/city_local/london.md
@@ -43,6 +43,8 @@ attend any public TWC London meetings.
   slip through the cracks and not be granted access. If you have been waiting
   without a response for more than a week or two after signing up, please email
   or DM us on Twitter and we can try to help get you in.
+  
+- To learn more about TWC London and your rights as a tech worker in the U.K., you can read more in our zine, [Tech Workers Unite] (https://archive.org/stream/techworkersunite/TechWorkersUnite). 
 
 ## Code of Conduct
 

--- a/city_local/london.md
+++ b/city_local/london.md
@@ -44,7 +44,7 @@ attend any public TWC London meetings.
   without a response for more than a week or two after signing up, please email
   or DM us on Twitter and we can try to help get you in.
   
-- To learn more about TWC London and your rights as a tech worker in the U.K., you can read more in our zine, [Tech Workers Unite] (https://archive.org/stream/techworkersunite/TechWorkersUnite). 
+- To learn more about TWC London and your rights as a tech worker in the U.K., you can read more in our zine, [Tech Workers Unite](https://archive.org/stream/techworkersunite/TechWorkersUnite). 
 
 ## Code of Conduct
 


### PR DESCRIPTION
A group of people in the London shard worked on a zine to promote organizing in UK workplaces.