### PR TITLE
Add clarification to slack signup form + minor code of conduct update

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -16,7 +16,15 @@ The Tech Workers Coalition seeks to redefine the relationship between tech worke
 
 ## Membership
 
-We are open to all workers in the tech industry, friends and allies. We believe in respect, compassion, understanding and inclusion. We expect all community members to act in accordance with these values.  We reserve the right to reject membership based on being employed in a management role (i.e. with firing power) or in being employed in a role that is in support of the prison-industrial complex (police, prosecutors, prison industry, etc). If you have any questions about this, feel free to [reach out via email](mailto:hello@techworkersco.org).
+We are open to all workers in the tech industry, friends and allies. We believe in respect, compassion, understanding and inclusion. We expect all community members to act in accordance with these values.
+
+We reserve the right to reject membership based on the following:
+- Being employed in a management role (i.e. with firing power)
+- Employed in a role that is in support of the prison-industrial complex (police, prosecutors, prison industry, etc)
+- Your desire to be part of TWC is compromised by a business interest. For example, you want access to our members to promote your product, or to do user testing
+- You work as a journalist
+
+If you have any questions about this, feel free to [reach out via email](mailto:hello@techworkersco.org).
 
 ## Values of Participation
 

--- a/join.md
+++ b/join.md
@@ -9,6 +9,8 @@ show_in_footer: true
 
 Our Slack is governed by the principles and rules in our [Community Guide](/community-guide). By joining, you agree to follow them. Our newsletter includes announcements and updates from the Tech Workers Coalition.
 
+If you are joining the slack, please keep in mind that you will be manually vetted before you are allowed in. Sometimes this can take a day or two. Please be patient with us!
+
 
 **Please provide the following:**
 
@@ -26,9 +28,6 @@ Our Slack is governed by the principles and rules in our [Community Guide](/comm
       <label for="social">Please provide two links to social media handles.</label>
       What we are looking for here is a way to validate that you meet the membership requirements laid out <a href="/community-guide#membership">here</a>. Linkedin is preferred, but anything that allows us to verify that you aren't a manager, journalist, etc is acceptable.
     </div>
-    <!-- <div>
-      We know some people don't use social media. What we are looking for here is a way to validate that you meet the membership requirements laid out <a href="/community-guide#membership">here</a>. Linkedin is preferred, but anything that allows us to verify that you aren't a manager
-    </div> -->
     <input id="social" required type="url" name="social_media_1">
     <input type="url" required name="social_media_2">
   </div>

--- a/join.md
+++ b/join.md
@@ -22,7 +22,13 @@ Our Slack is governed by the principles and rules in our [Community Guide](/comm
     <input id="name" type="text" required name="name">
   </div>
   <div>
-    <label for="social">Please provide two links to social handles (Twitter, Medium, personal blog, etc.):</label>
+    <div>
+      <label for="social">Please provide two links to social media handles.</label>
+      What we are looking for here is a way to validate that you meet the membership requirements laid out <a href="/community-guide#membership">here</a>. Linkedin is preferred, but anything that allows us to verify that you aren't a manager, journalist, etc is acceptable.
+    </div>
+    <!-- <div>
+      We know some people don't use social media. What we are looking for here is a way to validate that you meet the membership requirements laid out <a href="/community-guide#membership">here</a>. Linkedin is preferred, but anything that allows us to verify that you aren't a manager
+    </div> -->
     <input id="social" required type="url" name="social_media_1">
     <input type="url" required name="social_media_2">
   </div>


### PR DESCRIPTION
Specifically this PR attempts to clarify a few things for new members, as well as make explicit some rules that were not widely publicized

1 - clarify that we can reject membership if you are a journalist (functionally, we already do this) and if you have a conflicting business interest (this has been a recurring issue, and we should just write it down)

2 - there is a lot of confusion about getting on the slack. and often people will submit the form with information that doesn't really help. or they will submit it multiple times when they don't hear back immediately. so i've added some text to hopefully clarify what we are looking for, and why slack confirmation might not happen right away

I figure the code of conduct thing might be debatable, so I'm happy to let this PR sit for a bit until it's hashed out