### PR TITLE
minor edit for focus

### DIFF
--- a/index.md
+++ b/index.md
@@ -15,9 +15,6 @@ permalink: /
 <h3>{% t home.who_we_are.title %}</h3>
 <p>{% t home.who_we_are.description %}</p>
 
-<h3>{% t home.why_we_organize.title %}</h3>
-<p>{% t home.why_we_organize.description %}</p>
-
 <h3>{% t home.who_we_support.title %}</h3>
 <p>{% t home.who_we_support.description %}</p>
 


### PR DESCRIPTION
Nipping the 'why we organize' section because the blurb at the top of the page -- "Guided by our vision for an inclusive & equitable tech industry, TWC organizes to build worker power through rank & file self-organization and education" -- is clear & compelling, and makes it redundant. Also, without this section, 'who we are' flows nicely into 'who we support'.