### PR TITLE
add safe protest tips link to security page

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -13,7 +13,7 @@ home:
   summary: Guided by our vision for an inclusive & equitable tech industry, TWC organizes to build worker power through rank & file self-organization and education.
   black_lives_matter:
     title: Black Lives Matter
-    description: We encourage Tech Workers to stand with the Black Lives Matter movement as they fight for justice. To that end, we've put together <a href="/security">a list of security guides here</a> you can use to help protect yourself and your comrades.
+    description: We encourage Tech Workers to stand with the Black Lives Matter movement as they fight for justice. To that end, we've put together <a class="hover:white" href="/security">a list of security guides here</a> you can use to help protect yourself and your comrades.
   who_we_are:
     title: Who we are
     description: We are a coalition of workers in and around the tech industry, labor organizers, community organizers, and friends.

--- a/_includes/main.scss
+++ b/_includes/main.scss
@@ -93,6 +93,10 @@ button {
   color: $white;
 }
 
+.hover\:white:hover {
+  color: $white;
+}
+
 .navOverlay {
   background: $white;
   border-radius: 4px;

--- a/security.md
+++ b/security.md
@@ -25,4 +25,9 @@ The following is a list of digital security guides we've found to be particularl
       Security in a Box
     </a>
   </li>
+  <li>
+    <a noreferrer nofollow href="https://www.safeprotest.tips/">
+      Safe Protest Tips (partially built by TWC volunteers)
+    </a>
+  </li>
 </ul>


### PR DESCRIPTION
Just fulfilling a request. Adding a link to safeprotest.tips, a security site that was built with some help from TWC volunteers

also fixed a minor annoying css issue on link hover, for the security blurb on the homepage