### PR TITLE
add link to managers and allies slack on join form page

### DIFF
--- a/join.md
+++ b/join.md
@@ -9,33 +9,35 @@ show_in_footer: true
 
 Our Slack is governed by the principles and rules in our [Community Guide](/community-guide). By joining, you agree to follow them. [Our newsletter](https://news.techworkerscoalition.org) includes news, announcements, and updates from the Tech Workers Coalition. You can [subscribe here](https://news.techworkerscoalition.org/subscribe/)
 
-For joining the Slack, please keep in mind that you will be manually vetted before you are allowed in. Sometimes this can take a day or two. Please be patient with us!
+For joining the Slack, please keep in mind that you will be manually vetted according to our principles above before you are allowed in. Sometimes this can take a couple days. Vetting is done by volunteers, please be patient with us!
 
 <h3 class="marg-b-3">Please provide the following:</h3>
 
-<form class="join-form" action="https://ancient-ridge-68647.herokuapp.com/signup" method="POST" target="_blank">
+<form class="join-form" action="https://ancient-ridge-68647.herokuapp.com/signup" method="POST" target="_blank" class="marg-b-4">
   <label class="marg-b-3" for="email">
-    <div>Email:</div>
+    <div><b>Email:</b></div>
     <input id="email" type="email" required name="email">
   </label>
   <label class="marg-b-3" for="name">
-    <div>Name:</div>
+    <div><b>Name:</b></div>
     <input id="name" type="text" required name="name">
   </label>
   <label class="marg-b-3" for="social">
     <div>
       <b>Please provide two links to social media handles.</b>
-      What we are looking for here is a way to validate that you meet the membership requirements laid out <a href="/community-guide#membership">here</a>. Linkedin is preferred, but anything that allows us to verify that you aren't a manager, journalist, etc is acceptable.
+      What we want is a way to validate that you meet the membership requirements laid out <a href="/community-guide#membership">here</a>. Linkedin is preferred, but anything that allows us to verify that you aren't a manager, journalist, etc is acceptable.
     </div>
     <input placeholder="LinkedIn/Twitter/etc" id="social" required type="url" name="social_media_1">
     <input placeholder="LinkedIn/Twitter/etc" type="url" required name="social_media_2">
   </label>
   <label class="marg-b-3" for="company_name">
-    <div>Company Name (optional):</div>
+    <div><b>Company Name</b> (optional):</div>
+    <div>Including a company name helps you vet you.</div>
     <input id="company_name" type="text" name="company_name">
   </label>
   <label class="marg-b-3" for="referrer">
-    <div>How Did You Hear About Us? (optional):</div>
+    <div><b>How Did You Hear About Us?</b> (optional):</div>
+    <div>Including a referrer from an existing member can be a good way to get in the slack if you lack a social media presence. Also, please be specific! If you found us on search, don't just say "Google" (it's unclear if you mean the company or the search engine).</div>
     <input id="referrer" type="text" name="referrer">
   </label>
   <div class="marg-b-3 flex flex-row ai-ctr">
@@ -46,3 +48,8 @@ For joining the Slack, please keep in mind that you will be manually vetted befo
   <input type="hidden" name="redirect_uri" value="https://techworkerscoalition.org/slack-thanks" />
   <input type="submit" value="Submit">
 </form>
+
+
+# Don't qualify for the Slack?
+
+If you're a manager or someone not involved in tech, but you consider yourself a supporter of TWC, we recently setup a new 'Managers & Allies' slack you may join [here](https://join.slack.com/t/techworkersco-4fm8079/shared_invite/zt-h3jau11x-PIPDe4OWaGdYNNzv0RQbhQ).

--- a/join.md
+++ b/join.md
@@ -25,14 +25,14 @@ For joining the Slack, please keep in mind that you will be manually vetted acco
   <label class="marg-b-3" for="social">
     <div>
       <b>Please provide two links to social media handles.</b>
-      What we want is a way to validate that you meet the membership requirements laid out <a href="/community-guide#membership">here</a>. Linkedin is preferred, but anything that allows us to verify that you aren't a manager, journalist, etc is acceptable.
+      <div>We need a way to validate that you meet the membership requirements laid out <a href="/community-guide#membership">here</a>. Linkedin is preferred, but anything that allows us to verify that you aren't a manager, journalist, etc is acceptable.</div>
     </div>
     <input placeholder="LinkedIn/Twitter/etc" id="social" required type="url" name="social_media_1">
     <input placeholder="LinkedIn/Twitter/etc" type="url" required name="social_media_2">
   </label>
   <label class="marg-b-3" for="company_name">
     <div><b>Company Name</b> (optional):</div>
-    <div>Including a company name helps you vet you.</div>
+    <div>Including a company name helps us vet you.</div>
     <input id="company_name" type="text" name="company_name">
   </label>
   <label class="marg-b-3" for="referrer">
@@ -52,4 +52,4 @@ For joining the Slack, please keep in mind that you will be manually vetted acco
 
 # Don't qualify for the Slack?
 
-If you're a manager or someone not involved in tech, but you consider yourself a supporter of TWC, we recently setup a new 'Managers & Allies' slack you may join [here](https://join.slack.com/t/techworkersco-4fm8079/shared_invite/zt-h3jau11x-PIPDe4OWaGdYNNzv0RQbhQ).
+If you're a manager or someone not in tech, but you're a supporter of TWC, we recently setup a new 'Managers & Allies' slack you may join [here](https://join.slack.com/t/techworkersco-4fm8079/shared_invite/zt-h3jau11x-PIPDe4OWaGdYNNzv0RQbhQ).


### PR DESCRIPTION
does what the title says + i updated the form copy a little bit more

hopefully will reduce signup confusion and divert some manager types to the ally slack

<img width="831" alt="Screen Shot 2020-09-23 at 10 44 51 PM" src="https://user-images.githubusercontent.com/2379901/94094809-6a8eab00-fdee-11ea-9cc3-7ba7fe862b07.png">

