### PR TITLE
fix broken seattle calendar

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
   <meta name="description" content="{{ page.excerpt | default: site.description | strip_html | normalize_whitespace | truncate: 160 | escape }}">
-  <meta http-equiv="Content-Security-Policy" content="base-uri 'none'; connect-src 'self' https://www.googleapis.com; default-src 'none'; block-all-mixed-content; font-src 'self'; form-action https://ancient-ridge-68647.herokuapp.com 'self'; img-src 'self'; manifest-src 'self'; object-src 'none'; script-src 'self' ajax.googleapis.com https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js 'nonce-{% nonce %}'; style-src 'self' 'unsafe-inline'">
+  <meta http-equiv="Content-Security-Policy" content="base-uri 'none'; connect-src 'self' https://www.googleapis.com; default-src 'none'; frame-src https://calendar.google.com; block-all-mixed-content; font-src 'self'; form-action https://ancient-ridge-68647.herokuapp.com 'self'; img-src 'self'; manifest-src 'self'; object-src 'none'; script-src 'self' ajax.googleapis.com https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js 'nonce-{% nonce %}'; style-src 'self' 'unsafe-inline'">
   <style>
     {% capture styles %}
       {% include normalize.css %}


### PR DESCRIPTION
**feel free to review but dont merge yet**

seattle uses an iframe to embed their events calendar, which is busted since it's not a whitelisted url

not really a big deal since it's been inactive for a long time (they stopped publicizing their meetings for a bit) but needs to be fixed if they want to make their meetings public again