### PR TITLE
TravisCI possibly uses these for deployments?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,3 @@ _site
 .letsencrypt
 *.log
 .jekyll-cache/
-.bundle/
-vendor/


### PR DESCRIPTION
Revert #272 

The cache of the `_site/` output seems to not change since the .gitignored was updated, see logs https://travis-ci.org/github/techworkersco/twc-site/builds/752648883