### PR TITLE
Make a visible change to home page and press page, see if it resets c…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ _site
 .letsencrypt
 *.log
 .jekyll-cache/
+.bundle/
+vendor/

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -15,7 +15,7 @@ home:
   summary: Guided by our vision for an inclusive & equitable tech industry, TWC organizes to build worker power through rank & file self-organization and education.
   looking_for_union:
     title: Looking for a Tech Worker Union?
-    description: While TWC is strongly affiliated with several unions around the world, and counts many union members and organizers in our ranks, we are not a union ourselves. If you're'interested in unionizing, we can help! If you're curious what's out there, check out <a href="https://organize.fyi/">this (rough) list</a> of active and ongoing labor efforts in both tech and adjacent industries.
+    description: While TWC is strongly affiliated with several unions around the world, and counts many union members and organizers in our ranks, we are not a union ourselves. If you're interested in unionizing, we can help! If you're curious what is out there, check out <a href="https://organize.fyi/">this (rough) list</a> of active and ongoing labor efforts in both tech and adjacent industries.
   who_we_are:
     title: Who we are
     description: We are a coalition of workers in and around the tech industry, labor organizers, community organizers, and friends.

--- a/press.md
+++ b/press.md
@@ -1,9 +1,10 @@
 ---
 layout: page
 permalink: /press/
+title: Press
 ---
 
-<h1 class="marg-b-4">Press</h1>
+<h1 class="marg-b-4">{{page.title}}</h1>
 
 <ul>
   {% assign english_berlin_press = site.data.berlin_press | where:"lang",site.lang %}
@@ -11,7 +12,7 @@ permalink: /press/
   {% for post in posts  %}
     <article class="marg-b-4 flex">
         <img
-          alt=""
+          alt="Newspaper icon"
           aria-hidden
           class="marg-r-3 press-icon"
           role="presentation"


### PR DESCRIPTION
in travis by default `clean_up: true` is set, so I think we can keep .gitignore as is. Question is, can we reset cache of /press.html by changing the page itself? Currently https://techworkerscoalition.org/press.html works (listing three items instead of four) while https://techworkerscoalition.org/press and https://techworkerscoalition.org/press/ do not work. 

