### PR TITLE
Fix 404 page to actually be used

### DIFF
--- a/404.md
+++ b/404.md
@@ -1,9 +1,9 @@
 ---
 layout: page
-title: 404 Not found
+title: 404
 show_in_footer: false
+permalink: /404.html
 ---
-# 404
+
+# {{ page.title }}
 ## {% t global.404 %}
-
-


### PR DESCRIPTION
Currently only explicit /404.html page works

Either this or `permalink: /404/` will fix the page