### PR TITLE
fixes minor lang nav bug

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -24,7 +24,6 @@
           <svg aria-hidden="true" class="marg-r-1" width="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><path class="primarySvgFill" d="M16 2a14 14 0 100 28 14 14 0 000-28zm0 2c.3 0 .7.2 1.2.7.5.5 1 1.4 1.4 2.5.4 1 .8 2.3 1 3.8h-7.2a20 20 0 011-3.8c.4-1.1 1-2 1.4-2.5.5-.5.9-.7 1.2-.7zm-3.5.5l-1 2c-.5 1.3-.9 2.8-1.1 4.5H5c1.4-3 4-5.5 7.4-6.5zm7 0c3.3 1 6 3.4 7.4 6.5h-5.3a22.3 22.3 0 00-2-6.5zM4.4 13H10a34.4 34.4 0 000 6H4.4a12 12 0 010-6zm7.8 0h7.6a31.4 31.4 0 010 6h-7.6a31.5 31.5 0 010-6zm9.7 0h5.7a12 12 0 010 6H22a34.4 34.4 0 000-6zM5 21h5.3a22.3 22.3 0 002 6.5A12 12 0 015.2 21zm7.3 0h7.2a20 20 0 01-1 3.8c-.4 1.1-1 2-1.4 2.5-.5.5-.9.7-1.2.7-.3 0-.7-.2-1.2-.7-.5-.5-1-1.4-1.4-2.5a20 20 0 01-1-3.8zm9.2 0H27a12 12 0 01-7.4 6.5l1-2c.5-1.3.9-2.8 1.1-4.5z"/></svg>
           {{ site.lang }}
         </button>
-        {% if page.namespace %}
         <ul id="langNav" class="navOverlay abs hide list-style-none">
           {% assign languages = page.languages | default: site.languages %}
           {% for lang in languages %}
@@ -33,7 +32,7 @@
                 <div class="p-2 bg-black">
                   <b>{% t langs.{{ lang }} %}</b>
                 </div>
-              {% else %}
+              {% elsif page.namespace %}
                 <a href="{% tl {{ page.namespace }} {{ lang }} %}">
                   {% t langs.{{ lang }} %}
                 </a>
@@ -41,7 +40,6 @@
             </li>
           {% endfor %}
         </ul>
-        {% endif %}
       </div>
 
       <div class="flex flex-row ai-ctr rel">


### PR DESCRIPTION
see title. i just moved the `page.namespace` check farther in

the way it's setup now, the nav button remains visible no matter what. but the hidden nav is not rendered. which means that when you click it anywhere but the main 2 pages, you get nothing, even if there's a translation for that page

moving it in means it always at least renders the current language, but will also now actually render any other languages available for that specific page