### PR TITLE
Remove whitespacing between sources in collective-actions

### DIFF
--- a/_includes/collective-actions.html
+++ b/_includes/collective-actions.html
@@ -7,10 +7,7 @@
     <p>
       {{action.description}}
       {% assign source_count = 0 %}
-      {% for source in action.sources %}
-        {% assign source_count = source_count | plus: 1 %}
-        <sup><a href="{{source}}">[{{source_count}}]</a></sup>
-      {% endfor %}
+      {% for source in action.sources %}{% assign source_count = source_count | plus: 1 %}<sup><a href="{{source}}">[{{source_count}}]</a></sup>{% endfor %}
     </p>
   </div>
 


### PR DESCRIPTION
**Before**:
<img width="82" alt="Screenshot of footnotes with space in between" src="https://user-images.githubusercontent.com/7111514/109419858-e14c5780-79cf-11eb-8a48-064a4cab73ff.png">

**After**:
<img width="235" alt="Screenshot of footnotes with no whitespace in between" src="https://user-images.githubusercontent.com/7111514/109419859-e1e4ee00-79cf-11eb-9dbf-2d797a0b6599.png">
