### PR TITLE
add link to new job board

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -57,6 +57,8 @@ links:
     text: Tech Worker Bill of Rights
   - url: /community-guide/
     text: Community Guide
+  - url: /job-board
+    text: Union Job Board
   - url: /press
     text: Press
   - url: /security


### PR DESCRIPTION
see title, just adds a link to the newly created job board

i do want to do some cleanup, etc, but i think this is good for now. rather it just be out there