### PR TITLE
Change from default jdk for Focal and Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ before_install:
 
 language: ruby
 script: "./script/cibuild"
-jdk: openjdk8 
+jdk:
+  - openjdk8
 dist: focal # instead of default xenial per https://github.com/rvm/rvm/issues/5133#issuecomment-932342146
 deploy:
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
 
 language: ruby
 script: "./script/cibuild"
-#jdk: openjdk8 
+jdk: openjdk8 
 dist: focal # instead of default xenial per https://github.com/rvm/rvm/issues/5133#issuecomment-932342146
 deploy:
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ before_install:
 
 language: ruby
 script: "./script/cibuild"
-jdk:
-  - openjdk8
+jdk: openjdk10
 dist: focal # instead of default xenial per https://github.com/rvm/rvm/issues/5133#issuecomment-932342146
 deploy:
   skip_cleanup: true


### PR DESCRIPTION
This readds jdk8 as java version, which the s3-website gem needs to push
https://docs.travis-ci.com/user/reference/focal/#jvm-clojure-groovy-java-scala-support