### PR TITLE
Add Democracy Works & fix typos

### DIFF
--- a/_workplaces/Democracy-Works.md
+++ b/_workplaces/Democracy-Works.md
@@ -2,5 +2,6 @@
 organization: Democracy Works
 union: Democracy Workers (NewsGuild-CWA, Local 31222)
 union_twitter: DWCollectiveTNG
+union_website: https://www.democracyworkers.org/
 job_listings: https://democracy.works/careers
 ---

--- a/_workplaces/Democracy-Works.md
+++ b/_workplaces/Democracy-Works.md
@@ -1,0 +1,6 @@
+---
+organization: Democracy Works
+union: Democracy Workers (NewsGuild-CWA, Local 31222)
+union_twitter: DWCollectiveTNG
+job_listings: https://democracy.works/careers
+---

--- a/_workplaces/Kickstarter.md
+++ b/_workplaces/Kickstarter.md
@@ -1,8 +1,8 @@
 ---
 organization: Kickstarter
 division:
-union: Kickstarter United
+union: Kickstarter United (OPEIU Local 153)
 union_twitter: ksr_united
-union_website: OPEIU Local 153
+union_website: https://kickstarterunited.org/
 job_listings: https://jobs.kickstarter.com/
 ---

--- a/job-board.md
+++ b/job-board.md
@@ -22,8 +22,8 @@ languages: ["en"]
   {{content}}
 {% endif %}
 <p>
-{% if workplace.union_twitter %}<a href="https://twitter.com/{{ worplace.union_twitter }}">@{{ workplace.union_twitter }}</a>{% endif %} 
-{% if workplace.union_website %}<a href="https://twitter.com/{{ worplace.union_website }}">website</a>{% endif %}
+{% if workplace.union_twitter %}<a href="https://twitter.com/{{ workplace.union_twitter }}">@{{ workplace.union_twitter }}</a>{% endif %} 
+{% if workplace.union_website %}(<a href="{{ workplace.union_website }}">website</a>){% endif %}
 </p>
 <a href="{{ workplace.job_listings }}">{% t job_board.see_jobs %}&nbsp;></a>
 {% endfor %}


### PR DESCRIPTION
This PR adds [Democracy Works](https://democracy.works) to the list of union workplaces (its union being [Democracy Workers](https://www.democracyworkers.org), TNG-CWA local 31222).

It also fixes a couple of issues with `job-board.md`:

- typos were preventing links from working
- references to `union_website` were being turned into Twitter timeline links