### PR TITLE
Make it more transparent what to expect after signing up

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -57,7 +57,7 @@ collections:
 exclude_from_localizations: ["assets"]
 links:
   - url: /subscribe
-    text: Join our Slack
+    text: Join
   - url: /blog
     text: Blog  
   - url: /chapters

--- a/join.md
+++ b/join.md
@@ -15,7 +15,7 @@ Our Slack is governed by the principles and rules in our [Community Guide](/comm
 </div>
 
 <h3 class="marg-b-3">Please provide the following:</h3>
-<form class="join-form" method="POST" target="_blank" class="marg-b-4" data-netlify="true" action="/slack-thanks">
+<form class="join-form" method="POST" target="_blank" class="marg-b-4" data-netlify="true" action="/welcome">
   <label class="marg-b-3" for="email">
     <div><b>Email:</b></div>
     <input id="email" type="email" required name="email">

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[[redirects]]
+  from = "/slack-thanks/"
+  to = "/welcome"
+  status = 308
+  force = true

--- a/slack-thanks.md
+++ b/slack-thanks.md
@@ -1,8 +1,0 @@
----
-layout: page
-permalink: /slack-thanks/
----
-
-## Thanks for joining the Tech Workers Coalition! You'll hear back from us soon, stay close to your email inbox!
-
-If you haven't already, check out a [local chapter](/chapters) to find out when we are meeting in person.

--- a/welcome.md
+++ b/welcome.md
@@ -6,11 +6,11 @@ permalink: /welcome
 
 Congratulations on joining Tech Workers Coalition! Over four thousand tech workers have signed up because they believe in collective action and the ability to change the tech industry! 
 
-## What happen's next?
+## What happens next?
 Our volunteer team has received your information and will send you further information if you filled out the form. 
-1. You will automnatically be subscribed to two ActionNetwork newsletters
+1. You will automatically be subscribed to two different Action Network newsletters
     * <b>Internal newsletter</b> for upcoming events and updates
-    * <b>Interview-style</b> [TWC Newsletter](https://news.techworkerscoalition.org/) of different workplace struggles 
-2. You will also receive an invite to our [Slack](https://techworkersco.slack.com/), where you can meet tech workers from other TWC chapters 🌍 
+    * <b>Interview-style</b> [TWC Newsletter](https://news.techworkerscoalition.org/) on different workplace struggles 
+2. You will also receive an invite to our [Slack](https://techworkersco.slack.com/) where you can meet tech workers from other [chapters](/chapters) 🌍 
 3. If you have any further questions, you can contact us at hello@techworkerscoalition.org 
-4. Find your [local chapter](/chapters) here. If there does not exist one in your area, we are happy to help you start one! 
+4. Find your [local chapter](/chapters) here. If one does not exist in your area, we are happy to help you form one! 

--- a/welcome.md
+++ b/welcome.md
@@ -1,0 +1,16 @@
+---
+layout: page
+permalink: /welcome
+---
+# 🎉 Congratulations
+
+Congratulations on joining Tech Workers Coalition! Over four thousand tech workers have signed up because they believe in collective action and the ability to change the tech industry! 
+
+## What happen's next?
+Our volunteer team has received your information and will send you further information if you filled out the form. 
+1. You will automnatically be subscribed to two ActionNetwork newsletters
+    * <b>Internal newsletter</b> for upcoming events and updates
+    * <b>Interview-style</b> [TWC Newsletter](https://news.techworkerscoalition.org/) of different workplace struggles 
+2. You will also receive an invite to our [Slack](https://techworkersco.slack.com/), where you can meet tech workers from other TWC chapters 🌍 
+3. If you have any further questions, you can contact us at hello@techworkerscoalition.org 
+4. Find your [local chapter](/chapters) here. If there does not exist one in your area, we are happy to help you start one! 


### PR DESCRIPTION
1. When a user fills out [/subscribe](https://techworkerscoalition.org/subscribe/) they get redirected to a modernized [/welcome](https://deploy-preview-357--techworkersco.netlify.app/welcome), which was formerly /slack-thanks 
2. An expanded explanation of what happens after completing the form, the two auto-subscribes and conditional/manual slack invitation
## Before
<img width="861" alt="Screenshot 2024-02-18 at 21 39 41" src="https://github.com/techworkersco/twc-site/assets/7111514/d0934e32-f7ad-403b-8608-c3a65d7a065d">

## After
<img width="855" alt="Screenshot 2024-02-18 at 21 39 49" src="https://github.com/techworkersco/twc-site/assets/7111514/883e5fa3-30bd-4181-ae1c-0e4442bd112c">


