### PR TITLE
remove collective action in tech external link

### DIFF
--- a/index.md
+++ b/index.md
@@ -34,7 +34,6 @@ languages: ["en", "es", "fr", "it", "pt", "ru"]
 
 {% if site.lang == 'en' %}
   {% include newsletter.html %}
-  {% include collective-actions.html %}
   <h2 class="txt-2"> TWC in the Press</h2>
   <a href="/press">All Press mentions</a>
   {% include press.html limit=3%}


### PR DESCRIPTION
https://data.collectiveaction.tech/ has moved over to airtable, need to analyze how to reimport/use this database :D for now remove defunct github data source