### PR TITLE
Improve event images

### DIFF
--- a/_includes/event-card.html
+++ b/_includes/event-card.html
@@ -1,28 +1,30 @@
   
   <article class="p-3 marg-b-3 event-card flex items-center secondaryBg">
-    {% assign foundImage = 0 %}
-    {% assign image = 0 %}
-    {% assign images = event.content | split:"<img " %}
-    {% for image in images %}
+  {% assign foundImage = 0 %}  
+  {% if event.image %}
+    {% capture foundImage %} src="{{event.image}}" {% endcapture %}
+  {% else %}  
+    {% assign html_blocks = event.content | split:"<img " %}
+    {% for image in html_blocks %}
       {% if image contains 'src' %}
         {% if foundImage == 0 %}
           {% assign tags = image | split:"/>" | first | | split:" " %}
           {% for tag in tags %}
             {% if tag contains 'src' %}
-              {% assign image = tag %}
+              {% assign foundImage = tag %}
             {% endif %}
           {% endfor %}
-          {% assign foundImage = 1 %}
         {% endif %} 
       {% endif %}
     {% endfor %}
+  {% endif %}  
 
-    {% if image != 0 %}
+    {% if foundImage != 0 %}
       <img
-      {{image}}
+      {{foundImage}}
       alt=""
       class="bg-white marg-r-3 lh-1"
-      style="width:100px;height:100px"
+      style="width:100px;height:100px;object-fit:cover;"
     />
     {% else %}
       <div class="bg-white circ lh-1" style="min-width:100px;height:100px">  

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,7 +15,7 @@
     frame-src https://calendar.google.com https://app.netlify.com; 
     block-all-mixed-content; 
     font-src 'self'; 
-    img-src 'self' https://actionnetwork.org *.s3.amazonaws.com; 
+    img-src 'self' https://actionnetwork.org *.s3.amazonaws.com https://techworkersberlin.com https://techwerkers.nl; 
     manifest-src 'self'; 
     object-src https://actionnetwork.org; 
     script-src 'self' https://code.jquery.com https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js https://actionnetwork.org 'unsafe-inline' 'unsafe-eval';

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -14,16 +14,6 @@ backend:
 media_folder: "assets/img"
 
 collections:
-  - name: "blog" # Used in routes, e.g., /admin/collections/blog
-    slug: '{{year}}-{{month}}-{{day}}-{{slug}}'
-    label: "Blog"
-    folder: "_blog" # The path to the folder where the documents are stored
-    create: true # Allow users to create new documents in this collection
-    fields: # The fields for each document, usually in front matter
-      - {label: "Title", name: "title", widget: "string"} 
-      - {label: "Date", name: "date", widget: "datetime", picker_utc: true }
-      - {label: "Body", name: "body", widget: "markdown"}
-  
   - name: "event" # Used in routes, e.g., /admin/collections/blog
     label: "Event" # Used in the UI
     folder: "_events" # The path to the folder where the documents are stored
@@ -35,3 +25,14 @@ collections:
       - {label: "Time zones", name: "time_zones", widget: "select", multiple: true, default: ["US/Eastern"], min: 1, options: ["US/Eastern", "US/Pacific", "US/Central", "US/Mountain", "Europe/Berlin", "Europe/London"]}
       - {label: "Tags", name: "tags", widget: "list"}
       - {label: "Body", name: "body", widget: "markdown"}
+      - {label: "Preview image and SEO", name: "image", widget: "image", required: false}
+  - name: "blog" # Used in routes, e.g., /admin/collections/blog
+    slug: '{{year}}-{{month}}-{{day}}-{{slug}}'
+    label: "Blog"
+    folder: "_blog" # The path to the folder where the documents are stored
+    create: true # Allow users to create new documents in this collection
+    fields: # The fields for each document, usually in front matter
+      - {label: "Title", name: "title", widget: "string"} 
+      - {label: "Date", name: "date", widget: "datetime" }
+      - {label: "Body", name: "body", widget: "markdown"}
+    


### PR DESCRIPTION
* If an event has an image attribute, e.g from Berlin events it will now render those
* Enable explicit image to be set, which can be different from image rendered in body
* Refactor image search logic to be more clear

Sometimes image is silly, but that can be fixed by setting an explicit event image in such a case that is fit for 100x100px and or looks good when cover-position centered (css)
<img width="1026" alt="Screenshot 2024-09-05 at 20 40 14" src="https://github.com/user-attachments/assets/1f855562-35c7-4670-865d-086a8c25a352">

 