### PR TITLE
Remove Slack channel guides

### DIFF
--- a/_i18n/en/guide.md
+++ b/_i18n/en/guide.md
@@ -69,16 +69,8 @@ Projects should form their own topics within Slack. Many start with the prefix *
 - **Use direct messages.** Members of this Slack range in expertise, talent, and experience. Feel free to reach out to folks with specific questions or needs.This is also a good space to take tangential conversations—no need to do everything in public.
 - Avoid @channel or @here in #general or high traffic channels unless your message is important to everyone in that channel
 
-### Channel Guide
-Channels come and go on Slack, but here are some long-living channels:
-- #articles: interesting reads
-- #calendar: TWC events calendar items
-- #events: things going on that you might want to know about (not limited to TWC events)
-- #general: general announcements
-- #meetings: conversation about our org-wide meetings
-- #workplace-conditions: conversations about working conditions and experiences in the tech industry
-
 ## <a id="document-history" href="#document-history">Document History</a>
+- *2025-03-08: Removal of Slack channel guide*
 - *2019-12-11: Removal of defunct steering committee as per consensus between several locals*
 - *2019-11-04: Clarification regarding membership requirements*
 - *2018-07-22: Deleted old and out-of-date information, RK*

--- a/_i18n/fr/guide.md
+++ b/_i18n/fr/guide.md
@@ -69,16 +69,8 @@ Les projets doivent former leurs propres sujets dans Slack. Beaucoup commencent 
 - **Utilisez des messages directs.** Les membres de ce Slack se distinguent par leur expertise, leurs talents et leur expérience. N'hésitez pas à contacter les personnes qui ont des questions ou des besoins spécifiques. C'est également un bon espace pour prendre des conversations tangentielles - pas besoin de tout faire en public.
 - Évitez @channel ou @here dans les canaux #general ou à fort trafic, sauf si votre message est important pour tout le monde dans ce canal.
 
-### Guide Des Chaînes
-Les chaînes vont et viennent sur Slack, mais voici quelques chaînes à longue durée de vie:
-- #articles: lectures intéressantes
-- #calendar: Calendrier des événements TWC
-- #events: les choses qui se passent que vous voudrez peut-être connaître (non limitées aux événements TWC)
-- #general: annonces générales
-- #meetings: conversation sur nos réunions à l'échelle de l'organisation
-- #workplace-conditions: conversations sur les conditions de travail et les expériences dans l'industrie technologique
-
 ## <a id="document-history" href="#document-history">Historique Du Document</a>
+- *2025-03-08: Removal of Slack channel guide*
 - *2019-12-11: Retrait du comité directeur défunt selon consensus entre plusieurs sections locales *
 - *2019-11-04: Clarification concernant les conditions d'adhésion *
 - *2018-07-22: Informations anciennes et obsolètes supprimées, RK *

--- a/_i18n/pt/guide.md
+++ b/_i18n/pt/guide.md
@@ -74,18 +74,8 @@ Os projetos devem formar seus próprios tópicos no Slack. Muitos começam com o
 - **Use mensagens diretas.** Use mensagens diretas. Os membros deste Slack variam em níveis de conhecimento, talento e experiência. Sinta-se à vontade para entrar em contato com pessoas com perguntas ou necessidades específicas. Esse também é um bom espaço para conversas tangenciais - não é necessário fazer ou falar tudo em público.
 - Evite @channel ou @here nos canais #general ou de alto tráfego, a menos que sua mensagem seja realmente importante para todos nesse canal
 
-
-### Guia do canal
-Os canais vêm e vão no Slack, mas aqui estão alguns canais mais permanentes:
-- #articles: leituras interessantes
-- #calendar: calendário de eventos do TWC
-- #events: coisas que você pode querer saber (não limitado a eventos do TWC)
-- #general: anúncios gerais
-- #meetings: conversa sobre nossas reuniões em toda a organização
-- #workplace-conditions: conversas sobre condições e experiências de trabalho na indústria de tecnologia
-
-
 ## <a id="document-history" href="#document-history">Documentação Histórica (em inglês)</a>
+- *2025-03-08: Removal of Slack channel guide*
 - *2019-12-11: Removal of defunct steering committee as per consensus between several locals*
 - *2019-11-04: Clarification regarding membership requirements*
 - *2018-07-22: Deleted old and out-of-date information, RK*

--- a/chapter_local/london.md
+++ b/chapter_local/london.md
@@ -16,7 +16,7 @@ The London, UK, chapter of the TWC formed in early
 in September 2019, moving to [MayDay Rooms](https://www.maydayrooms.org/)
 thereafter.
 
-One year later the chapter closed, in favor of opening a [United Tech & Allied Workers]([url](https://utaw.tech/)) branch within the Communication Workers' Union.
+One year later the chapter closed, in favor of opening a [United Tech & Allied Workers](https://utaw.tech/) branch within the Communication Workers' Union.
 
 Our definition of a "tech worker" is anyone involved in the tech industry in
 any capacity &mdash; including programmers, designers, product managers,


### PR DESCRIPTION
Remove Slack channel guides, as per [Slack thread](https://techworkersco.slack.com/archives/C04MYU5NY5P/p1741371060427679?thread_ts=1741314827.419889&cid=C04MYU5NY5P).

Added a log dated for March 8th as that's when I believe this pull request will be merged.