### PR TITLE
add Dutch events to global website

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,7 +37,9 @@ jekyll_get_data:
   - data: berlin_press
     url: https://raw.githubusercontent.com/techworkersco/twc-site-berlin/develop/_data/press.yml  
   - data: berlin_events
-    url: https://techworkersberlin.com/events.yml   
+    url: https://techworkersberlin.com/events.yml
+  - data: nl_events
+    url: https://techwerkers.nl/en/events/index.yaml     
 exclude:
   - .jekyll-cache/
 # also update index.md

--- a/_includes/events.html
+++ b/_includes/events.html
@@ -1,6 +1,6 @@
 {% assign berlin_events = site.data.berlin_events %}
 {% assign nl_events = site.data.nl_events %}
-{% assign events = site.events | concat: berlin_events | sort: 'date' | filter_tags: include.tags %}
+{% assign events = site.events | concat: nl_events | concat: berlin_events | sort: 'date' | filter_tags: include.tags %}
 {% assign future_events = events | where_exp: "event", "event.date >= site.time" %}
 {% assign past_events = events | where_exp: "event", "site.time > event.date" %}
 

--- a/_plugins/get_data.rb
+++ b/_plugins/get_data.rb
@@ -2,7 +2,6 @@ require "jekyll"
 require 'json'
 require 'deep_merge'
 require 'open-uri'
-# require 'pry'
 
 module JekyllGetData
   class GetDataGenerator < Jekyll::Generator


### PR DESCRIPTION
Adds events from English events listed in https://techwerkers.nl/en/events/ to the https://techworkerscoalition.org/events/ and homepage (of
<img width="617" alt="Screenshot 2025-05-06 at 20 57 30" src="https://github.com/user-attachments/assets/3528f053-8559-41bf-8b1b-1561098803ac" />
 upcoming events). I do think the generic TWC Netherlands image could be more clear, that it's Netherlands chapter. 

Example screenshot of Dutch events on TWC Global page now available 

<img width="656" alt="Screenshot 2025-05-06 at 20 57 37" src="https://github.com/user-attachments/assets/95d7e6fb-3ff2-4f54-9a99-0d4b2b22bbaa" />
