### PR TITLE
Move twc-nl events sourcing from a twc-global specific page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,7 +39,7 @@ jekyll_get_data:
   - data: berlin_events
     url: https://techworkersberlin.com/events.yml
   - data: nl_events
-    url: https://techwerkers.nl/en/events/index.yaml     
+    url: https://techwerkers.nl/en/twc-global/index.yaml     
 exclude:
   - .jekyll-cache/
 # also update index.md


### PR DESCRIPTION
https://github.com/techworkersco/twc-site-nl/pull/112 will create a new path for twc-global specific layouts etc.

Helps us to keep the code organised when there are specific layouts needed for twc-global

The yaml: https://deploy-preview-112--twc-site-nl.netlify.app/en/twc-global/index.yaml