### PR TITLE
Include timezone data for consistency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,14 +18,13 @@ gem 'base64'
 # gem 'pry'
 
 gem 'tzinfo'
+gem 'tzinfo-data'
+
 # If you have any plugins, put them here!
 group :jekyll_plugins do
    gem "jekyll-feed", "~> 0.11"
    gem "jekyll-multiple-languages-plugin", github: "techworkersco/jekyll-i18n"
 end
-
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-# gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem "webrick", "~> 1.7"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,8 @@ GEM
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2025.2)
+      tzinfo (>= 1.0.0)
     unicode-display_width (2.6.0)
     webrick (1.9.1)
     yell (2.2.2)
@@ -155,6 +157,7 @@ DEPENDENCIES
   logger
   rake (~> 13.1)
   tzinfo
+  tzinfo-data
   webrick (~> 1.7)
 
 RUBY VERSION


### PR DESCRIPTION
We use the [TZInfo gem][0] for timezone data. To quote its docs:

> By default, TZInfo will attempt to use TZInfo::Data. If TZInfo::Data is not available, then TZInfo will search for a zoneinfo directory instead.

We weren't using `TZInfo::Data`, so we were at the mercy of the system's zoneinfo database.

My system lacked at least one of the timezones we use, `US/Pacific`, so I got this error when running `jekyll serve` (reformatted slightly):

    .../gems/tzinfo-2.0.6/lib/tzinfo/data_source.rb:321:
    in 'TZInfo::DataSource#validate_timezone_identifier':
    Invalid identifier: US/Pacific (TZInfo::InvalidTimezoneIdentifier)

This installs the `tzinfo-data` gem to stop using the system zoneinfo.

This fixed my problem, but I also think this is a useful change for others. Now everyone can rely on the same database instead of their system's, which may vary between developers.

Feel free to reject if this is not desired.

[0]: https://tzinfo.github.io/