### PR TITLE
Chapter cleanups, remove dead links

### DIFF
--- a/_data/chapters.yaml
+++ b/_data/chapters.yaml
@@ -55,7 +55,6 @@ chapters:
     activity_level: inactive
   - text: Berlin
     twitter: TechWorkersBER
-    # facebook: TechWorkersBER # broken link, what's the real one?
     url: https://techworkersberlin.com/
     activity_level: active
   - text: Dublin

--- a/_data/chapters.yaml
+++ b/_data/chapters.yaml
@@ -2,24 +2,21 @@ chapters:
   - text: Austin
     url: /austin
     twitter: twcatx
-    meetup: Tech-Workers-Coalition-ATX/
-    facebook: twcatx
-    activity_level: midactive
+    facebook: https://www.facebook.com/twcatx
+    activity_level: semiactive
   - text: Brasil
     url: /pt/brasil
     activity_level: inactive
   - text: Boston
-    url: https://boston.techworkerscoalition.org/
     twitter: techworkersBOS
     activity_level: inactive
   - text: Chicago
     url: /chicago
-    twitter: chicago_twc
     activity_level: inactive
   - text: DC
     url: /dc
     twitter: dctechworkers
-    facebook: DC-Tech-Workers-Coalition
+    facebook: https://www.facebook.com/DC-Tech-Workers-Coalition-338770966854335/
     activity_level: semiactive
   - text: Denver
     twitter: twc_den
@@ -29,7 +26,7 @@ chapters:
     activity_level: inactive
   - text: North Carolina
     url: /north-carolina
-    activity_level: midactive  
+    activity_level: semiactive  
   - text: NYC
     url: /nyc
     twitter: techworkerscony
@@ -39,9 +36,8 @@ chapters:
     url: /pdx
     activity_level: active
   - text: San Diego
-    url: https://twcsandiego.org/
     twitter: twcsandiego
-    activity_level: active
+    activity_level: semiactive
   - text: San Jose
     twitter: twc_sanjose
     activity_level: inactive
@@ -52,7 +48,6 @@ chapters:
     url: /bay-area
     activity_level: active
   - text: South Florida
-    twitter: southfltechworkers
     activity_level: inactive
   - text: Bangalore
     twitter: TechiesSpeakUp
@@ -60,20 +55,19 @@ chapters:
     activity_level: inactive
   - text: Berlin
     twitter: TechWorkersBER
-    facebook: TechWorkersBER
+    # facebook: TechWorkersBER # broken link, what's the real one?
     url: https://techworkersberlin.com/
     activity_level: active
   - text: Dublin
-    twitter: TWBIreland
     activity_level: inactive
   - text: London
     twitter: TechWorkersLDN
-    facebook: TechWorkersLDN
+    facebook: https://www.facebook.com/TechWorkersLDN
     url: /london
     activity_level: inactive
   - text: Italia
     twitter: twcitalia
-    facebook: twcita
+    facebook: https://www.facebook.com/twcita
     url: https://twc-italia.org
     activity_level: active
   - text: Netherlands

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -28,7 +28,7 @@ home:
   how_we_work:
     title: How we work
     description: |
-      We’re a democratically structured, all-volunteer, and worker-led organization. Get <a href="/subscribe">involved</a> and find an <a href="/events">event below</a>! You can also <a href="mailto:hello@techworkerscoalition.org">reach us by email.</a>
+      We’re a democratically structured, all-volunteer, and worker-led organization. <b><a href="/subscribe">Get involved</a> and find (or help start) a <a href="/chapters">local chapter</a>!</b> You can also <a href="mailto:hello@techworkerscoalition.org">reach us by email.</a>
   check_out_meeting:
     title: Find a local chapter
     link: |

--- a/chapter_local/austin.md
+++ b/chapter_local/austin.md
@@ -11,7 +11,7 @@ This is the Austin, TX chapter of the TWC.
 - We are a coalition of workers in and around the tech industry, labor organizers, community organizers, and friends.
 
 ## Connect With Us
-- Visit our [Meetup](https://www.meetup.com/Tech-Workers-Coalition-ATX/) to find the latest events.
+- Find us in `#local-austin` in the [TWC Slack](/subscribe/),
 - Follow us on Twitter at [@twcatx](https://twitter.com/twcatx).
 
 ## Code of Conduct

--- a/chapter_local/chicago.md
+++ b/chapter_local/chicago.md
@@ -11,8 +11,7 @@ This is the Chicago chapter of the TWC.
 - We are a coalition of workers in and around the tech industry, labor organizers, community organizers, and friends living and working in the greater Chicagoland area.
 
 ## Connect With Us
-- Visit our [website](https://chicagotwc.org) for info and updates
-- Follow us on Twitter [@chicago_twc](https://twitter.com/chicago_twc)
+- Find us in `#local-chicago` in the [TWC Slack](/subscribe/),
 - Get in direct contact with us at [chicagotechworkers@gmail.com](mailto:chicagotechworkers@gmail.com)
 
 ## Code of Conduct

--- a/chapters.md
+++ b/chapters.md
@@ -5,13 +5,14 @@ permalink: /chapters/
 ---
 {% assign activity_levels = "active,semiactive,inactive" | split: ','%}
 {% for level in activity_levels %}
-  <h2>{{level | capitalize}} chapters</h2>
+  <h2>{% if level == "inactive" %}Inactive and former chapters{% else %}{{level | capitalize}} chapters{% endif %}</h2>
   {% assign chapters = site.data.chapters.chapters | where:"activity_level",level | sort: "text" %}
   {% for chapter in chapters %}
   <ul class="list-style-none marg-b-3 pad-l-3">
     <b>{% if chapter.url %}<a href="{{chapter.url}}">{{chapter.text}}</a>{% else if%}{{chapter.text}}{% endif %}</b>
     {% if chapter.twitter %} · <a href="https://twitter.com/{{chapter.twitter}}">Twitter</a>{% endif %}
     {% if chapter.meetup %} · <a href="https://meetup.com/{{chapter.meetup}}">Meetup</a>{% endif %}
+    {% if chapter.facebook %} · <a href="{{chapter.facebook}}">Facebook</a>{% endif %}
   </ul>
 {% endfor %}
 {% endfor %}  

--- a/join.md
+++ b/join.md
@@ -44,7 +44,7 @@ Our Slack is governed by the principles and rules in our [Community Guide](/comm
     <div class="marg-b-2">This helps us connect you with local organizing efforts. If there isn't already a chapter in your area, we'd love to chat with you about starting one!</div>
     <select id="nearby-chapter" name="nearby-chapter">
       <option value="">Select a chapter</option>
-      {% assign active_chapters = site.data.chapters.chapters | where_exp:"chapter", "chapter.activity_level == 'active'" %}
+      {% assign active_chapters = site.data.chapters.chapters | where_exp:"chapter", "chapter.activity_level == 'active' or chapter.activity_level == 'semiactive'" | sort: "text" %}
       {% for chapter in active_chapters %}
       <option value="{{chapter.text | replace: ' ', '-' | downcase }}">{{chapter.text}}</option>
       {% endfor %}


### PR DESCRIPTION
- "midactive" -> "semiactive" activity level to fix logic
- Include semiactive chapters in /subscribe dropdown
- Add facebook pages to chapter page
- Remove all dead chapter links
- Link to chapter page from homepage