### PR TITLE
Update Bay Area onboarding language

### DIFF
--- a/chapter_local/sf-bay-area.md
+++ b/chapter_local/sf-bay-area.md
@@ -22,9 +22,9 @@ We are the Bay Area chapter of TWC. As of summer 2025, most of our active member
 
 ## Connect With Us
 
-We're excited to connect with new members! After you join the [TWC Slack](/subscribe/), come introduce yourself in `#local-bay-area`, share your ideas and learn about (or plan!) local events.
+We're excited to connect with new members! When you [join TWC](/subscribe/), select the "SF Bay Area" chapter to be added to our local mailing list. Then, come introduce yourself in `#local-bay-area` Slack channel, share your ideas and learn about (or plan!) local events.
 
-You can also **[fill out this quick form](https://docs.google.com/forms/d/e/1FAIpQLSeXhHLTrtWpQr7eAPfValJvSZQt0EVlDyxZLxt53gthkrLDkw/viewform) to join our Bay Area chapter mailing list** where we periodically share upcoming events.
+We periodically share upcoming local events in our chapter email newsletter. You can also find them below.
 <br/><br/>
 
 ## Upcoming Events

--- a/join.md
+++ b/join.md
@@ -53,7 +53,7 @@ Our Slack is governed by the principles and rules in our [Community Guide](/comm
   <div id="chapter-outreach-fields" style="display: none;">
     <label class="marg-b-3" for="wants-outreach">
       <input id="outreach" type="checkbox" name="outreach" value="wants-outreach" style="margin-right: 8px;">
-      <b>Are you interested in 1:1 outreach from someone in the chapter?</b> (optional)
+      <b>Are you interested in 1:1 outreach from someone in TWC?</b> (optional)
     </label>
   </div>
   <input type="submit" value="Submit">


### PR DESCRIPTION
- Remove the google form which we're deprecating now that chapter tagging happens automatically in the "Join" form
- Update the 1:1 checkbox to specify someone "from TWC" will reach out, not set expectation that it will be a local chapter member.