### PR TITLE
Events: swap "San Fransisco" (sic) w "Bay Area"

### DIFF
--- a/_events/bay-area-book-club-the-play-in-the-system.md
+++ b/_events/bay-area-book-club-the-play-in-the-system.md
@@ -2,7 +2,7 @@
 title: "Bay Area Book Club: The Play in the System"
 date: 2025-08-30 17:00
 locations:
-  - San Fransisco
+  - Bay Area
 time_zones:
   - US/Pacific
 image: /assets/img/image.png

--- a/_events/bay-area-general-meeting.md
+++ b/_events/bay-area-general-meeting.md
@@ -2,7 +2,7 @@
 title: Bay Area General Meeting
 date: 2025-09-24 21:00
 locations:
-  - San Fransisco
+  - Bay Area
 time_zones:
   - US/Pacific
 ---

--- a/_events/bay-area-may-day-march.md
+++ b/_events/bay-area-may-day-march.md
@@ -2,7 +2,7 @@
 title: Bay Area May Day march
 date: 2025-05-01 19:00
 locations:
-  - San Fransisco
+  - Bay Area
 time_zones:
   - US/Pacific
 image: /assets/img/slide-1-english.png

--- a/_events/bay-area-meetup-1.md
+++ b/_events/bay-area-meetup-1.md
@@ -2,7 +2,7 @@
 title: Bay Area meetup
 date: 2025-06-05 21:00
 locations:
-  - San Fransisco
+  - Bay Area
 time_zones:
   - US/Pacific
 image: /assets/img/twc_bayarea_0625.png

--- a/_events/bay-area-meetup-2.md
+++ b/_events/bay-area-meetup-2.md
@@ -2,7 +2,7 @@
 title: Bay Area meetup
 date: 2025-08-07 21:00
 locations:
-  - San Fransisco
+  - Bay Area
 time_zones:
   - US/Pacific
 image: /assets/img/twc_bayarea_0825.png

--- a/_events/bay-area-meetup.md
+++ b/_events/bay-area-meetup.md
@@ -2,7 +2,7 @@
 title: Bay Area meetup
 date: 2025-04-02 21:00
 locations:
-  - San Fransisco
+  - Bay Area
 time_zones:
   - US/Pacific
 image: /assets/img/twc_bayarea_0425.png

--- a/_events/bay-area-tech-workers-for-palestine-meetup-7amleh-x-twc.md
+++ b/_events/bay-area-tech-workers-for-palestine-meetup-7amleh-x-twc.md
@@ -2,7 +2,7 @@
 title: Bay Area Tech Workers for Palestine Meetup (7amleh x TWC)
 date: 2025-09-16 21:00
 locations:
-  - San Fransisco
+  - Bay Area
 time_zones:
   - US/Pacific
 image: /assets/img/image-2025-08-25-191806.jpg

--- a/_events/digital-security-workshop-documentary-sample-screening.md
+++ b/_events/digital-security-workshop-documentary-sample-screening.md
@@ -2,7 +2,7 @@
 title: Digital Security Workshop & Documentary Sample Screening
 date: 2025-08-03 17:00
 locations:
-  - San Fransisco
+  - Bay Area
 time_zones:
   - US/Pacific
 image: /assets/img/518042481_17890367598277826_3477586235890025810_n.jpg

--- a/_events/solidarity-with-labor-forum.md
+++ b/_events/solidarity-with-labor-forum.md
@@ -3,7 +3,7 @@ title: "Wake Up SF: Strike for 15 and Our Homes / Despiertate SF: Huelga para 15
   y Nuestros Hogares"
 date: 2016-04-14 09:00
 locations:
-  - San Fransisco
+  - Bay Area
 time_zones:
   - US/Pacific
 ---

--- a/_events/tech-against-totalitarianism.md
+++ b/_events/tech-against-totalitarianism.md
@@ -2,7 +2,7 @@
 title: Tech Against Totalitarianism
 date: 2025-05-10 20:00
 locations:
-  - San Fransisco
+  - Bay Area
 time_zones:
   - US/Pacific
 image: /assets/img/twc_nota_v3.png

--- a/_events/wake-up-sf-strike-for-15-and-our-homes-despiertate-sf-huelga-para-15-y-nuestros-hogares.md
+++ b/_events/wake-up-sf-strike-for-15-and-our-homes-despiertate-sf-huelga-para-15-y-nuestros-hogares.md
@@ -2,7 +2,7 @@
 title: December Organization meeting
 date: 2016-12-06 22:00
 locations:
-  - San Fransisco
+  - Bay Area
 time_zones:
   - US/Pacific
 ---

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -21,7 +21,7 @@ collections:
     fields: # The fields for each document, usually in front matter
       - {label: "Title", name: "title", widget: "string"}
       - {label: "Date (use New York time)", name: "date", widget: "datetime", format: "YYYY-MM-DD HH:mm" }
-      - {label: "Locations", name: "locations", widget: "select", multiple: true, default: ["Global"], min: 1, options: ["Global", "Online", "Berlin", "San Fransisco", "San Diego", "Portland", "New York", "Austin", "Netherlands", "Italy", "Washington DC", "Boston", "Los Angeles", "Seattle"]}
+      - {label: "Locations", name: "locations", widget: "select", multiple: true, default: ["Global"], min: 1, options: ["Global", "Online", "Berlin", "Bay Area", "San Diego", "Portland", "New York", "Austin", "Netherlands", "Italy", "Washington DC", "Boston", "Los Angeles", "Seattle"]}
       - {label: "Time zones", name: "time_zones", widget: "select", multiple: true, default: ["US/Eastern"], min: 1, options: ["US/Eastern", "US/Pacific", "US/Central", "US/Mountain", "Europe/Berlin", "Europe/London"]}
       - {label: "Tags", name: "tags", widget: "list"}
       - {label: "Body", name: "body", widget: "markdown"}


### PR DESCRIPTION
This event label was misspelled and inaccurate (since our chapter is Bay Area, not SF). Attempting to fix in the CMS config and all existing events.