### PR TITLE
Remove Pitchfork from Unionized Workplaces

### DIFF
--- a/_data/workplaces.yml
+++ b/_data/workplaces.yml
@@ -5,13 +5,6 @@
     union_website: https://alphabetworkersunion.org/
     job_listings: https://careers.google.com/
 
--   organization: Pitchfork Media
-    division:
-    union: Pitchfork Union
-    union_twitter: p4kunion
-    union_website: 
-    job_listings: https://pitchfork.com/news/tags/jobs/ 
-
 -   organization: Democracy Works
     union: Democracy Workers (NewsGuild-CWA, Local 31222)
     union_twitter: DWCollectiveTNG


### PR DESCRIPTION
In an effort to update and maintain documentation referenced from the bookmarks section in the TWC job-board channel:
<img width="683" height="258" alt="image" src="https://github.com/user-attachments/assets/bc51021e-ecdf-49cb-96a3-32624095f76a" />

"[Pitchfork faces layoffs and restructuring under Condé Nast](https://www.npr.org/2024/01/18/1225446347/pitchfork-faces-layoffs-and-restructuring-under-conde-nast)"