### PR TITLE
Remove target="_blank" from join.md

### DIFF
--- a/join.md
+++ b/join.md
@@ -9,7 +9,7 @@ permalink: /subscribe/
 Our Slack is governed by the principles and rules in our [Community Guide](/community-guide). By joining, you agree to follow them.
 
 <h3 class="marg-b-3">Please provide the following:</h3>
-<form class="join-form" method="POST" target="_blank" class="marg-b-4" data-netlify="true" action="/welcome" netlify-honeypot="bot-field">
+<form class="join-form" method="POST" class="marg-b-4" data-netlify="true" action="/welcome" netlify-honeypot="bot-field">
   <label style="display:none">
     Don’t fill this out if you’re human: <input name="bot-field" />
   </label>


### PR DESCRIPTION
Open the form response (typically the `/welcome` page) in the same tab instead of a new tab. The current behavior leaves a tab open with the form and data populated, which caused re-submissions. This change should reduce the behavior of users coming back later, forgetting whether they submitted or not, and submitting again.

Ref: https://www.notion.so/Redirect-from-join-form-Welcome-on-submit-stay-on-same-tab-2b876edfa0728014be18dbaa9efbb103