### PR TITLE
Update workplace info for Nava

### DIFF
--- a/_data/workplaces.yml
+++ b/_data/workplaces.yml
@@ -52,7 +52,7 @@
 
 - organization: Nava PBC
   division:
-  union: Nava United (OPEIU Local 1010)
+  union: Nava United (OPEIU Local 153)
   union_twitter: nava_united
   union_website: https://www.navaunited.org/
-  job_listings: https://jobs.lever.co/nava
+  job_listings: https://www.navapbc.com/open-roles


### PR DESCRIPTION
Nava is now part of OPEIU Local 153 and no longer uses lever for the job board/hiring