### PR TITLE
Start adding responsive features to the redesign

### DIFF
--- a/_includes/new.css
+++ b/_includes/new.css
@@ -38,7 +38,7 @@
     U+2215, U+FEFF, U+FFFD;
 }
 
-@layer reset, base, main, utils;
+@layer reset, base, main, utils, overrides;
 
 @layer reset {
   /* see https://www.joshwcomeau.com/css/custom-css-reset */
@@ -140,6 +140,8 @@
 }
 
 @layer base {
+  body { overflow-x: clip; }
+
   :root {
     /* see https://utopia.fyi/  */
     --step--2: clamp(0.7813rem, 0.7736rem + 0.0341vw, 0.8rem);
@@ -169,6 +171,8 @@
     --space-l-xl: clamp(2.25rem, 1.6364rem + 2.7273vw, 3.75rem);
     --space-xl-2xl: clamp(3.375rem, 2.7102rem + 2.9545vw, 5rem);
     --space-2xl-3xl: clamp(4.5rem, 3.2727rem + 5.4545vw, 7.5rem);
+
+    --content-max-width: 1440px;
 
     /* https://huetone.ardov.me/?palette=N4IgdghgtgpiBcIAqB1AwgAgMYHsAOAniADQgAWArjAM4IDaoksCIAChQE54A2cpu3HB1rw6IAMQATAGYwAzNOkkJWAEaSAjIuXiI01QDZtpcQE4ATKdPGJAdnMGsN8QFYAHHJfO5bjbawaOuaqAAzuSiYaBiFuLuY6IRAhIZ4gALoAvsSM0HCIAEowksoCQiJi4oqSWJKmOopYACxYIfXS1lZttlF8EtLRpnJyOljRIeYuOqa2yRoQOgaNIY0arSZykslhQeZb8ZnZ4LksAOIcEET8OILC9BIwLg8POpKNr6866l-FJhAuf38dLFgZMTAZTODwTpGtIYTCdENEcNIgFUQlNhj0lkcsxEAAZCAANxgYEkMA4JWuZTu4hgBhgWl6UkcTgiKkSijZuka0xgqiBjVs-jcC1MLlUEDqJjhMX560a5gccokWmWjSZq2SclaBxxeWQMAg3EpN3KEghnK5IS05lhCRCkjctR0UVUah%2BEmSpjcnRMyVs03mfrCqhcWHtclUkft5g0sYSGkTqyxaVIABccGAaHcXGsQJrlLs89q80s87m82NlDM825kspTPXMkA */
     /* todo(maximsmol): these are sRGB, we should try upgrading to P3/Rec2020 */
@@ -304,7 +308,7 @@
 
   h2,
   .h2 {
-    font-size: var(--step-4);
+    font-size: min(9vw, var(--step-4));
   }
 
   h3,
@@ -314,7 +318,7 @@
 
   h4,
   .h4 {
-    font-size: var(--step-2);
+    font-size: min(6vw, var(--step-2));
   }
 
   h5,
@@ -374,9 +378,15 @@
     > header {
       display: flex;
 
-      padding: var(--space-s) var(--space-l);
+      padding-top: var(--space-s);
+      padding-bottom: var(--space-s);
+      gap: var(--space-s);
+      justify-content: space-between;
+      width: 100%;
 
       > h1 {
+        min-width: 290px;
+        block-size: 60px;
         display: flex;
         align-items: center;
         gap: var(--space-s);
@@ -391,28 +401,43 @@
 
       > nav {
         flex-grow: 1;
-
-        display: flex;
-        justify-content: flex-end;
+        flex-shrink: 1;
+        max-width: 700px;
 
         > ul {
+          justify-content: space-around;
           display: flex;
           align-items: center;
-          gap: var(--space-m);
 
           list-style: none;
+          text-wrap: nowrap;
         }
       }
     }
 
+    /* [jneen] set max-width for main (non-fullwidth) elements.
+     * padding is applied on *all* device widths - on larger
+     * screens, the horizontal margin will be the naturally-
+     * occurring margin after max-width, plus the padding
+     * defined here.
+     */
+    > header, > main > article {
+      max-width: var(--content-max-width);
+      padding-left: var(--space-xs);
+      padding-right: var(--space-xs);
+      margin: 0 auto;
+    }
+
     > main {
       .banner {
-        block-size: calc(1.5 * var(--space-3xl));
+        block-size: calc(min(30vw, 1.5 * var(--space-3xl)));
         overflow: hidden;
+        overflow-x: clip;
       }
 
       .hero {
-        padding: var(--space-s) var(--space-l);
+        overflow-x: clip;
+        padding: var(--space-xs);
         padding-top: var(--space-l);
 
         h2 {
@@ -432,6 +457,7 @@
             flex-direction: column;
 
             text-align: justify;
+            text-wrap: nowrap;
 
             .h4 {
               line-height: 1.5;
@@ -457,6 +483,8 @@
               display: flex;
               gap: var(--space-2xs);
               justify-content: flex-end;
+
+              > svg { width: 24px; height: 24px; }
             }
           }
         }
@@ -470,12 +498,15 @@
         > .cards {
           list-style: none;
 
-          display: grid;
-          grid-template-columns: repeat(3, 1fr);
+          display: flex;
+          flex-wrap: wrap;
+          justify-content: space-evenly;
           gap: var(--space-s);
 
           li {
             padding: var(--space-s);
+            flex-basis: 330px;
+            flex-grow: 1;
 
             border: 2px solid var(--color-red-400);
             box-shadow: var(--color-red-400) -4px 6px;
@@ -506,5 +537,39 @@
         }
       }
     }
+  }
+}
+
+@layer overrides {
+  @media(max-width: 600px) {
+    header {
+      ul {
+        align-items: flex-end;
+        > li { flex-basis: 0; }
+        gap: 0;
+        flex-direction: column;
+      }
+    }
+
+    .hero h2 {
+      .title { margin: 0 auto; }
+      > svg { display: none; }
+    }
+  }
+
+  @media(max-width: 1000px) {
+    header {
+      flex-direction: column;
+      align-items: flex-end;
+
+      h1 {
+        width: 100%;
+      }
+    }
+
+    .icon-lines {
+      display: none;
+    }
+
   }
 }

--- a/_includes/new.css
+++ b/_includes/new.css
@@ -38,7 +38,7 @@
     U+2215, U+FEFF, U+FFFD;
 }
 
-@layer reset, base, main, utils, overrides;
+@layer reset, base, main, utils;
 
 @layer reset {
   /* see https://www.joshwcomeau.com/css/custom-css-reset */
@@ -139,9 +139,12 @@
   }
 }
 
-@layer base {
-  body { overflow-x: clip; }
+/*
+note: minimum supported width 360px matching the smallest preset in Firefox,
+which is Galaxy S10/S10+ Android 11
+*/
 
+@layer base {
   :root {
     /* see https://utopia.fyi/  */
     --step--2: clamp(0.7813rem, 0.7736rem + 0.0341vw, 0.8rem);
@@ -172,7 +175,7 @@
     --space-xl-2xl: clamp(3.375rem, 2.7102rem + 2.9545vw, 5rem);
     --space-2xl-3xl: clamp(4.5rem, 3.2727rem + 5.4545vw, 7.5rem);
 
-    --content-max-width: 1440px;
+    --space-s-l: clamp(1.125rem, 0.5625rem + 2.5vw, 2.5rem);
 
     /* https://huetone.ardov.me/?palette=N4IgdghgtgpiBcIAqB1AwgAgMYHsAOAniADQgAWArjAM4IDaoksCIAChQE54A2cpu3HB1rw6IAMQATAGYwAzNOkkJWAEaSAjIuXiI01QDZtpcQE4ATKdPGJAdnMGsN8QFYAHHJfO5bjbawaOuaqAAzuSiYaBiFuLuY6IRAhIZ4gALoAvsSM0HCIAEowksoCQiJi4oqSWJKmOopYACxYIfXS1lZttlF8EtLRpnJyOljRIeYuOqa2yRoQOgaNIY0arSZykslhQeZb8ZnZ4LksAOIcEET8OILC9BIwLg8POpKNr6866l-FJhAuf38dLFgZMTAZTODwTpGtIYTCdENEcNIgFUQlNhj0lkcsxEAAZCAANxgYEkMA4JWuZTu4hgBhgWl6UkcTgiKkSijZuka0xgqiBjVs-jcC1MLlUEDqJjhMX560a5gccokWmWjSZq2SclaBxxeWQMAg3EpN3KEghnK5IS05lhCRCkjctR0UVUah%2BEmSpjcnRMyVs03mfrCqhcWHtclUkft5g0sYSGkTqyxaVIABccGAaHcXGsQJrlLs89q80s87m82NlDM825kspTPXMkA */
     /* todo(maximsmol): these are sRGB, we should try upgrading to P3/Rec2020 */
@@ -308,7 +311,7 @@
 
   h2,
   .h2 {
-    font-size: min(9vw, var(--step-4));
+    font-size: var(--step-4);
   }
 
   h3,
@@ -318,7 +321,7 @@
 
   h4,
   .h4 {
-    font-size: min(6vw, var(--step-2));
+    font-size: var(--step-2);
   }
 
   h5,
@@ -374,19 +377,36 @@
   body {
     display: flex;
     flex-direction: column;
+    align-items: center;
 
-    > header {
+    .header-padding {
+      display: flex;
+      justify-content: center;
+
+      padding: var(--space-s) var(--space-s-l);
+      inline-size: 100%;
+    }
+
+    header {
       display: flex;
 
-      padding-top: var(--space-s);
-      padding-bottom: var(--space-s);
-      gap: var(--space-s);
-      justify-content: space-between;
-      width: 100%;
+      gap: var(--space-xs) var(--space-s-m);
+      align-items: center;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+
+      max-inline-size: 1440px;
+      inline-size: 100%;
+
+      @media (max-width: 600px) {
+        display: grid;
+        grid-template-columns: 1fr auto;
+      }
 
       > h1 {
-        min-width: 290px;
-        block-size: 60px;
+        flex-grow: 1;
+        padding-right: var(--space-s);
+
         display: flex;
         align-items: center;
         gap: var(--space-s);
@@ -394,45 +414,69 @@
         font-size: inherit;
 
         > .logo {
-          block-size: 100%;
-          aspect-ratio: 1/1;
+          height: 2lh;
         }
       }
 
-      > nav {
-        flex-grow: 1;
-        flex-shrink: 1;
-        max-width: 700px;
+      nav {
+        display: contents;
 
         > ul {
-          justify-content: space-around;
-          display: flex;
-          align-items: center;
+          display: contents;
 
           list-style: none;
           text-wrap: nowrap;
+
+          @media (max-width: 600px) {
+            li {
+              grid-column: span 2;
+
+              display: flex;
+              justify-content: flex-end;
+            }
+          }
+        }
+      }
+
+      @media (max-width: 600px) {
+        > nav {
+          display: none;
+        }
+      }
+
+      > details {
+        @media (min-width: 600px) {
+          display: none;
+        }
+
+        &[open] {
+          display: contents;
+        }
+
+        &::details-content {
+          content-visibility: visible;
+        }
+
+        > summary {
+          list-style: none;
+
+          @media (min-width: 600px) {
+            display: none;
+          }
+
+          svg {
+            width: 2em;
+          }
         }
       }
     }
 
-    /* [jneen] set max-width for main (non-fullwidth) elements.
-     * padding is applied on *all* device widths - on larger
-     * screens, the horizontal margin will be the naturally-
-     * occurring margin after max-width, plus the padding
-     * defined here.
-     */
-    > header, > main > article {
-      max-width: var(--content-max-width);
-      padding-left: var(--space-xs);
-      padding-right: var(--space-xs);
-      margin: 0 auto;
-    }
-
     > main {
+      max-inline-size: 1440px;
+
       .banner {
         block-size: calc(min(30vw, 1.5 * var(--space-3xl)));
-        overflow: hidden;
-        overflow-x: clip;
+        overflow: clip;
       }
 
       .hero {
@@ -446,10 +490,20 @@
           display: flex;
           gap: var(--space-s);
 
+          font-size: min(9vw, var(--step-4));
+
+          @media (max-width: 800px) {
+            justify-content: center;
+          }
+
           > svg {
             color: var(--color-red-400);
 
             width: 2lh;
+
+            @media (max-width: 600px) {
+              display: none;
+            }
           }
 
           > .title {
@@ -461,6 +515,8 @@
 
             .h4 {
               line-height: 1.5;
+
+              font-size: min(6vw, var(--step-2));
             }
           }
 
@@ -475,6 +531,10 @@
             flex-direction: column;
             gap: var(--space-2xs);
 
+            @media (max-width: 800px) {
+              display: none;
+            }
+
             div {
               flex-grow: 1;
               flex-basis: 0;
@@ -484,7 +544,84 @@
               gap: var(--space-2xs);
               justify-content: flex-end;
 
-              > svg { width: 24px; height: 24px; }
+              /*> svg {
+                width: 24px;
+                height: 24px;
+              }*/
+
+              @media (max-width: 1200px) {
+                > svg:nth-child(10) {
+                  display: none;
+                }
+              }
+
+              @media (max-width: 1100px) {
+                > svg:nth-child(9) {
+                  display: none;
+                }
+              }
+
+              @media (max-width: 1050px) {
+                > svg:nth-child(8) {
+                  display: none;
+                }
+              }
+
+              @media (max-width: 1000px) {
+                > svg:nth-child(7) {
+                  display: none;
+                }
+
+                &:nth-child(2) > svg:nth-child(6) {
+                  display: none;
+                }
+
+                &:nth-child(3) > svg:nth-child(5) {
+                  display: none;
+                }
+              }
+
+              @media (max-width: 950px) {
+                > svg:nth-child(6) {
+                  display: none;
+                }
+
+                &:nth-child(2) > svg:nth-child(5) {
+                  display: none;
+                }
+
+                &:nth-child(3) > svg:nth-child(4) {
+                  display: none;
+                }
+              }
+
+              @media (max-width: 900px) {
+                > svg:nth-child(5) {
+                  display: none;
+                }
+
+                &:nth-child(2) > svg:nth-child(4) {
+                  display: none;
+                }
+
+                &:nth-child(3) > svg:nth-child(3) {
+                  display: none;
+                }
+              }
+
+              @media (max-width: 850px) {
+                > svg:nth-child(4) {
+                  display: none;
+                }
+
+                &:nth-child(2) > svg:nth-child(3) {
+                  display: none;
+                }
+
+                &:nth-child(3) > svg:nth-child(2) {
+                  display: none;
+                }
+              }
             }
           }
         }
@@ -537,39 +674,5 @@
         }
       }
     }
-  }
-}
-
-@layer overrides {
-  @media(max-width: 600px) {
-    header {
-      ul {
-        align-items: flex-end;
-        > li { flex-basis: 0; }
-        gap: 0;
-        flex-direction: column;
-      }
-    }
-
-    .hero h2 {
-      .title { margin: 0 auto; }
-      > svg { display: none; }
-    }
-  }
-
-  @media(max-width: 1000px) {
-    header {
-      flex-direction: column;
-      align-items: flex-end;
-
-      h1 {
-        width: 100%;
-      }
-    }
-
-    .icon-lines {
-      display: none;
-    }
-
   }
 }

--- a/index.11ty.tsx
+++ b/index.11ty.tsx
@@ -28,6 +28,38 @@ const renderCss = async () => {
 };
 
 export const render = async () => {
+  const nav = (
+    <nav class="monospace">
+      <ul>
+        <li>
+          <a href="/about" class="button">
+            About Us
+          </a>
+        </li>
+        <li>
+          <a href="/blog" class="button">
+            Blog
+          </a>
+        </li>
+        <li>
+          <a href="/resources" class="button">
+            Resources
+          </a>
+        </li>
+        <li>
+          <a href="/newsletter" class="button">
+            Newsletter
+          </a>
+        </li>
+        <li>
+          <a href="/donate" class="button framed">
+            Donate
+          </a>
+        </li>
+      </ul>
+    </nav>
+  );
+
   return {
     type: "root",
     children: [
@@ -65,13 +97,14 @@ export const render = async () => {
           {/* todo(maximsmol): WebMention? */}
         </head>
         <body>
-          <header>
-            <h1>
-              <span class="logo">
+          <div class="header-padding">
+            <header>
+              <h1>
                 <svg
                   alt=""
                   xmlns="http://www.w3.org/2000/svg"
                   viewBox="0 0 400 400"
+                  class="logo"
                 >
                   <path d="M94.44,261.32v-102.21h-20.44v-20.44h61.32v20.44h-20.44v102.21h-20.44Z" />
                   <path d="M148.9,261.32v-122.65h20.44v102.21h20.44v-102.21h20.44v102.21h20.44v-102.21h20.44v122.65h-102.21Z" />
@@ -84,43 +117,36 @@ export const render = async () => {
                   <path d="M252.32,83.05c4.89,4.99,6.21,12.78,2.72,19.25-4.29,7.94-14.24,10.91-22.18,6.62-7.94-4.29-10.91-14.24-6.62-22.18,3.43-6.36,10.5-9.53,17.26-8.34l26.22-45.36,8.8,4.75M235.04,91.5c-1.67,3.09-.51,6.96,2.58,8.63s6.96.51,8.63-2.58.51-6.96-2.58-8.63-6.96-.51-8.63,2.58Z" />
                   <path d="M199.38,38.42c4.89,4.99,6.21,12.78,2.72,19.25-4.29,7.94-14.24,10.91-22.18,6.62s-10.91-14.24-6.62-22.18c3.43-6.36,10.5-9.53,17.26-8.34l9.56-16.86,8.8,4.75M182.1,46.86c-1.67,3.09-.51,6.96,2.58,8.63s6.96.51,8.63-2.58c1.67-3.09.51-6.96-2.58-8.63s-6.96-.51-8.63,2.58Z" />
                 </svg>
-              </span>
-              <span>
-                Tech&nbsp;Workers
-                <br />
-                Coalition
-              </span>
-            </h1>
-            <nav class="monospace">
-              <ul>
-                <li>
-                  <a href="/about" class="button">
-                    About Us
-                  </a>
-                </li>
-                <li>
-                  <a href="/blog" class="button">
-                    Blog
-                  </a>
-                </li>
-                <li>
-                  <a href="/resources" class="button">
-                    Resources
-                  </a>
-                </li>
-                <li>
-                  <a href="/newsletter" class="button">
-                    Newsletter
-                  </a>
-                </li>
-                <li>
-                  <a href="/donate" class="button framed">
-                    Donate
-                  </a>
-                </li>
-              </ul>
-            </nav>
-          </header>
+                <span>
+                  Tech&nbsp;Workers
+                  <br />
+                  Coalition
+                </span>
+              </h1>
+              <details>
+                <summary>
+                  {/* lucide-menu */}
+                  <svg
+                    alt="Navigation"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <path d="M4 5h16" />
+                    <path d="M4 12h16" />
+                    <path d="M4 19h16" />
+                  </svg>
+                </summary>
+
+                {nav}
+              </details>
+              {nav}
+            </header>
+          </div>
           <main>
             <div class="banner">
               <img src="/assets/img/header.jpg" alt="" />


### PR DESCRIPTION
* Switches to a max-width based layout instead of defining absolute padding. This allows for us to have smaller padding on small devices, and not blow up massively on large TVs etc
* The hero section now uses flexbox and wraps naturally for the tablet and phone widths.
* Added a `@layer overrides` for responsive overrides - including making some decorative icons disappear entirely at smaller sizes.

### Full width
<img width="1509" height="627" alt="image" src="https://github.com/user-attachments/assets/aaff0835-59f0-4e44-9ea8-cea66ed683ce" />

### Mid width (tablets)
<img width="823" height="756" alt="image" src="https://github.com/user-attachments/assets/9fe93f1b-2f60-4ae1-acac-ba5baafeddbd" />

### Small width (phones)
<img width="428" height="808" alt="image" src="https://github.com/user-attachments/assets/a9fb8743-741d-46a4-87eb-c70f8ee8a3ab" />

