### PR TITLE
Add YouTube channel to nav & footer, featured video embed on homepage

### DIFF
--- a/_includes/main.css
+++ b/_includes/main.css
@@ -469,7 +469,10 @@
     width: 240px;
 
     a {
-      display: block;
+      display: flex;
+      align-content: center;
+      align-items: center;
+      gap: 4px;
       padding: 8px;
     }
 
@@ -656,6 +659,13 @@
     padding: 2rem 0;
 
     font-size: var(--step--1);
+
+    li > a {
+      display: flex;
+      align-content: center;
+      align-items: center;
+      gap: 4px;
+    }
   }
 
   form {

--- a/_layouts/default.11ty.tsx
+++ b/_layouts/default.11ty.tsx
@@ -24,6 +24,7 @@ const links = [
   { url: "/job-board", text: "Union Job Board" },
   { url: "/press", text: "Press mentions" },
   { url: "/security", text: "Security Tips" },
+  { url: "https://www.youtube.com/@techworkerscoalitionvideos", text: "YouTube" },
 ];
 
 const renderCss = async () => {
@@ -47,6 +48,20 @@ const renderCss = async () => {
   // todo(maximsmol): does this to track dependencies on the CSS files somehow?
 
   return Buffer.from(res.code).toString();
+};
+
+const getLinkProps = (url: string) => {
+  const isExternal = url.includes("youtube.com") || url.startsWith("http");
+  
+  if (isExternal) {
+    return {
+      target: "_blank",
+      rel: "noopener noreferrer",
+      ariaLabel: "Opens in a new tab"
+    };
+  }
+  
+  return {}; // Return nothing for internal links
 };
 
 export const render = async ({
@@ -107,6 +122,8 @@ export const render = async ({
                 "https://calendar.google.com",
                 "https://app.netlify.com",
                 "https://dev.techworkerscoalition.org",
+                "https://www.youtube.com",
+                "https://www.youtube-nocookie.com",
               ],
               "font-src": ["'self'"],
               "img-src": [
@@ -230,7 +247,26 @@ export const render = async ({
                     >
                       {links.map((x) => (
                         <li>
-                          <a href={x.url}>{x.text}</a>
+                          <a href={x.url} {...getLinkProps(x.url)}>{x.text}
+                            {x.url.includes("youtube") ? (
+                              <svg
+                                role="img"
+                                aria-hidden="true"
+                                focusable="false"
+                                class="primarySvgFill"
+                                height="16"
+                                width="16"
+                                xmlns="https://www.w3.org/2000/svg"
+                                viewBox="0 0 16 16"
+                                fill-rule="evenodd"
+                                clip-rule="evenodd"
+                                stroke-linejoin="round"
+                                stroke-miterlimit="1.4"
+                              >
+                                <path d="M14 2.7L8.4 8.4a.5.5 0 01-.8-.8L13.3 2H9.5a.5.5 0 010-1h5a.5.5 0 01.5.5v5a.5.5 0 01-1 0V2.7zM5 3H2.5C1.7 3 1 3.7 1 4.5v9c0 .8.7 1.5 1.5 1.5h9a1.5 1.5 0 001.5-1.5V11a.5.5 0 00-1 0v2.5a.5.5 0 01-.5.5h-9a.5.5 0 01-.5-.5v-9c0-.3.2-.5.5-.5H5a.5.5 0 000-1z" fill-rule="nonzero"/>
+                              </svg>
+                            ) : null}
+                          </a>
                         </li>
                       ))}
                     </ul>
@@ -258,7 +294,26 @@ export const render = async ({
               <ul class="d:flex flex-wrap d:flex-row list-style-none">
                 {links.map((x) => (
                   <li class="d:c-1/3 marg-b-3 d:marg-r-3">
-                    <a href={x.url}>{x.text}</a>
+                    <a href={x.url} {...getLinkProps(x.url)}>{x.text}
+                      {x.url.includes("youtube") ? (
+                        <svg
+                          role="img"
+                          aria-hidden="true"
+                          focusable="false"
+                          class="primarySvgFill"
+                          height="16"
+                          width="16"
+                          xmlns="https://www.w3.org/2000/svg"
+                          viewBox="0 0 16 16"
+                          fill-rule="evenodd"
+                          clip-rule="evenodd"
+                          stroke-linejoin="round"
+                          stroke-miterlimit="1.4"
+                        >
+                          <path d="M14 2.7L8.4 8.4a.5.5 0 01-.8-.8L13.3 2H9.5a.5.5 0 010-1h5a.5.5 0 01.5.5v5a.5.5 0 01-1 0V2.7zM5 3H2.5C1.7 3 1 3.7 1 4.5v9c0 .8.7 1.5 1.5 1.5h9a1.5 1.5 0 001.5-1.5V11a.5.5 0 00-1 0v2.5a.5.5 0 01-.5.5h-9a.5.5 0 01-.5-.5v-9c0-.3.2-.5.5-.5H5a.5.5 0 000-1z" fill-rule="nonzero"/>
+                        </svg>
+                      ) : null}
+                    </a>
                   </li>
                 ))}
                 <li>

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -239,6 +239,40 @@ export default async (cfg) => {
     },
   });
   cfg.addTemplateFormats("mdx");
+  
+  cfg.addShortcode("featuredVideo", (videoId) => {
+    if (!videoId) return '';
+
+    return `
+      <div class="featured-video-wrapper">
+        <div class="featured-video-facade" 
+            id="youtube-${videoId}"
+            style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; background: #000; cursor: pointer;"
+            onclick="
+              const iframe = document.createElement('iframe');
+              iframe.setAttribute('src', 'https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1');
+              iframe.setAttribute('title', 'Featured Video');
+              iframe.setAttribute('frameborder', '0');
+              iframe.setAttribute('allow', 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture');
+              iframe.setAttribute('allowfullscreen', 'true');
+              iframe.setAttribute('style', 'position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;');
+              this.innerHTML = '';
+              this.appendChild(iframe);
+            ">
+          <img src="https://img.youtube.com/vi/${videoId}/maxresdefault.jpg" 
+            alt="Featured Video Thumbnail" 
+            style="position: absolute; top: 0; left: 0; right: 0; width: 100%; max-width: 100%; height: 100%; object-fit: cover; opacity: 0.85;"
+            onerror="this.src='https://img.youtube.com/vi/${videoId}/hqdefault.jpg';">
+          <div class="play-button" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); width: 68px; height: 48px; background: rgba(30, 30, 30, 0.9); border-radius: 12px; display: flex; align-items: center; justify-content: center; transition: background 0.2s;">
+            <svg viewBox="0 0 24 24" style="width: 20px; height: 20px; fill: white;"><path d="M8 5v14l11-7z"/></svg>
+          </div>
+        </div>
+      </div>
+      <style>
+        .featured-video-facade:hover .play-button { background: #FF0000 !important; }
+      </style>
+    `;
+  });
 
   const remoteDataSrcs = [
     {

--- a/index.md
+++ b/index.md
@@ -41,3 +41,11 @@ permalink: /
 <a href="/press" class="button">See more press mentions</a>
 
 </section>
+
+<section>
+  <h2>Featured Video</h2>
+  <!-- Swap out YouTube video id here -->
+  {% featuredVideo "jlAbwmoai-0" %}
+
+  <a href="https://www.youtube.com/@techworkerscoalitionvideos" target="_blank" rel="noopener noreferrer" aria-label="Opens in a new tab" class="button">See more videos on YouTube</a>
+</section>


### PR DESCRIPTION
This adds:
- An external YouTube channel link to the nav and footer, respectively
<img width="2880" height="1800" alt="localhost_8080_ (1)" src="https://github.com/user-attachments/assets/53d7c8e3-957f-4821-8eb3-e48bc4b73003" />
<img width="1170" height="2532" alt="localhost_8080_(iPhone 12 Pro) (2)" src="https://github.com/user-attachments/assets/7f97f2f0-fd01-4b40-9e75-8e603b73aa22" />
<img width="1170" height="2532" alt="localhost_8080_(iPhone 12 Pro) (1)" src="https://github.com/user-attachments/assets/1c42d1c2-bdcf-470e-a532-32ed663864f3" />

- A video section on the homepage with YouTube embed and a CTA to view the rest of the YouTube channel. The video slot can be swapped out by changing the video id. Currently using the latest video published to the channel
<img width="2880" height="1800" alt="localhost_8080_" src="https://github.com/user-attachments/assets/05545282-9d6c-4f32-bc71-9b6a9958bbfa" />
<img width="1170" height="2532" alt="localhost_8080_(iPhone 12 Pro)" src="https://github.com/user-attachments/assets/5cf781f2-1a15-42dd-92c3-c503777b19bb" />